### PR TITLE
test: wait for writes to be seen in journal specs

### DIFF
--- a/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
@@ -4,14 +4,21 @@
 
 package akka.persistence.dynamodb.journal
 
+import scala.concurrent.duration._
+
+import akka.actor.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.adapter._
 import akka.persistence.CapabilityFlag
+import akka.persistence.JournalProtocol.RecoverySuccess
+import akka.persistence.JournalProtocol.ReplayMessages
 import akka.persistence.dynamodb.TestConfig
 import akka.persistence.dynamodb.TestDbLifecycle
 import akka.persistence.journal.JournalSpec
+import akka.testkit.TestProbe
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
 
 object DynamoDBJournalSpec {
   val config = DynamoDBJournalSpec.testConfig()
@@ -32,13 +39,28 @@ object DynamoDBJournalSpec {
   }
 }
 
-class DynamoDBJournalSpec extends JournalSpec(DynamoDBJournalSpec.config) with TestDbLifecycle {
+abstract class DynamoDBJournalBaseSpec(config: Config)
+    extends JournalSpec(config)
+    with TestDbLifecycle
+    with Eventually {
+
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
+
   override def typedSystem: ActorSystem[_] = system.toTyped
+
+  // always eventually consistent reads with dynamodb-local, wait for writes to be seen
+  override def writeMessages(fromSnr: Int, toSnr: Int, pid: String, sender: ActorRef, writerUuid: String): Unit = {
+    super.writeMessages(fromSnr, toSnr, pid, sender, writerUuid)
+    val probe = TestProbe()
+    eventually(timeout(3.seconds), interval(100.millis)) {
+      journal ! ReplayMessages(fromSnr, toSnr, max = 0, pid, probe.ref)
+      probe.expectMsg(RecoverySuccess(toSnr))
+    }
+  }
 }
 
-class DynamoDBJournalWithMetaSpec extends JournalSpec(DynamoDBJournalSpec.configWithMeta) with TestDbLifecycle {
-  override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
+class DynamoDBJournalSpec extends DynamoDBJournalBaseSpec(DynamoDBJournalSpec.config)
+
+class DynamoDBJournalWithMetaSpec extends DynamoDBJournalBaseSpec(DynamoDBJournalSpec.configWithMeta) {
   protected override def supportsMetadata: CapabilityFlag = CapabilityFlag.on()
-  override def typedSystem: ActorSystem[_] = system.toTyped
 }


### PR DESCRIPTION
Follow up to flaky tests in https://github.com/lightbend/akka-persistence-dynamodb-private/pull/4#discussion_r1616142085.

Looks like reads are always eventually consistent for local DynamoDB:

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html#DynamoDBLocal.Differences

> Read operations are eventually consistent. However, due to the speed of DynamoDB running on your computer, most reads appear to be strongly consistent.

Update journal spec to check we can see messages that have been written. Is that enough to ensure subsequent reads will also be consistent? Will run tests several times to see if this works.