### PR TITLE
feat: OffsetStore

### DIFF
--- a/projection/src/main/resources/logback-test.xml
+++ b/projection/src/main/resources/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%X{akkaAddress}] [%marker] [%thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender"/>
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka.projection" level="DEBUG" />
+    <logger name="akka.persistence.dynamodb" level="DEBUG" />
+
+
+    <root level="INFO">
+        <appender-ref ref="CapturingAppender"/>
+<!--        <appender-ref ref="STDOUT"/>-->
+    </root>
+
+</configuration>

--- a/projection/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
@@ -34,7 +34,7 @@ object DynamoDBProjectionSettings {
   def apply(config: Config): DynamoDBProjectionSettings = {
     new DynamoDBProjectionSettings(
       timestampOffsetTable = config.getString("offset-store.timestamp-offset-table"),
-      useClient = config.getString("use-connection-factory"),
+      useClient = config.getString("use-client"),
       timeWindow = config.getDuration("offset-store.time-window"),
       keepNumberOfEntries = config.getInt("offset-store.keep-number-of-entries"),
       evictInterval = config.getDuration("offset-store.evict-interval"),

--- a/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -286,7 +286,7 @@ private[projection] class DynamoDBOffsetStore(
     }
   }
 
-  private def load(pid: Pid): Future[Done] = {
+  def load(pid: Pid): Future[Done] = {
     val oldState = state.get()
     val slice = persistenceExt.sliceForPersistenceId(pid)
     dao.load(slice, pid).map {
@@ -299,7 +299,7 @@ private[projection] class DynamoDBOffsetStore(
     }
   }
 
-  private def load(pids: IndexedSeq[Pid]): Future[Done] = {
+  def load(pids: IndexedSeq[Pid]): Future[Done] = {
     val oldState = state.get()
     val pidsToLoad = pids.filterNot(oldState.contains)
     if (pidsToLoad.isEmpty)

--- a/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -10,7 +10,7 @@ import java.time.{ Duration => JDuration }
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
-import scala.collection.immutable
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -48,37 +48,29 @@ private[projection] object DynamoDBOffsetStore {
       fromBacktracking: Boolean,
       fromPubSub: Boolean,
       fromSnapshot: Boolean)
-  final case class RecordWithProjectionKey(record: Record, projectionKey: String)
 
   object State {
-    val empty: State = State(Map.empty, Vector.empty, Instant.EPOCH, 0)
+    val empty: State = State(Map.empty, Map.empty, Instant.EPOCH, 0)
 
-    def apply(records: immutable.IndexedSeq[Record]): State = {
-      if (records.isEmpty) empty
-      else empty.add(records)
-    }
+    def apply(latestBySlice: Map[Int, Instant]): State =
+      if (latestBySlice.isEmpty) empty
+      else new State(Map.empty, latestBySlice, Instant.EPOCH, 0)
+
   }
 
   final case class State(
       byPid: Map[Pid, Record],
-      latest: immutable.IndexedSeq[Record],
+      latestBySlice: Map[Int, Instant],
       oldestTimestamp: Instant,
       sizeAfterEvict: Int) {
 
     def size: Int = byPid.size
 
     def latestTimestamp: Instant =
-      if (latest.isEmpty) Instant.EPOCH
-      else latest.head.timestamp
+      if (latestBySlice.isEmpty) Instant.EPOCH
+      else latestBySlice.valuesIterator.max
 
-    def latestOffset: Option[TimestampOffset] = {
-      if (latest.isEmpty)
-        None
-      else
-        Some(TimestampOffset(latestTimestamp, latest.map(r => r.pid -> r.seqNr).toMap))
-    }
-
-    def add(records: immutable.IndexedSeq[Record]): State = {
+    def add(records: IndexedSeq[Record]): State = {
       records.foldLeft(this) { case (acc, r) =>
         val newByPid =
           acc.byPid.get(r.pid) match {
@@ -91,23 +83,17 @@ private[projection] object DynamoDBOffsetStore {
               acc.byPid.updated(r.pid, r)
           }
 
-        val latestTimestamp = acc.latestTimestamp
-        val newLatest =
-          if (r.timestamp.isAfter(latestTimestamp)) {
-            Vector(r)
-          } else if (r.timestamp == latestTimestamp) {
-            acc.latest.find(_.pid == r.pid) match {
-              case None                 => acc.latest :+ r
-              case Some(existingRecord) =>
-                // keep highest seqNr
-                if (r.seqNr >= existingRecord.seqNr)
-                  acc.latest.filterNot(_.pid == r.pid) :+ r
-                else
-                  acc.latest
-            }
-          } else {
-            acc.latest // older than existing latest, keep existing latest
+        val newLatestBySlice =
+          acc.latestBySlice.get(r.slice) match {
+            case Some(existing) =>
+              if (r.timestamp.isAfter(existing))
+                acc.latestBySlice.updated(r.slice, r.timestamp)
+              else
+                acc.latestBySlice
+            case None =>
+              acc.latestBySlice.updated(r.slice, r.timestamp)
           }
+
         val newOldestTimestamp =
           if (acc.oldestTimestamp == Instant.EPOCH)
             r.timestamp // first record
@@ -116,9 +102,12 @@ private[projection] object DynamoDBOffsetStore {
           else
             acc.oldestTimestamp // this is the normal case
 
-        acc.copy(byPid = newByPid, latest = newLatest, oldestTimestamp = newOldestTimestamp)
+        acc.copy(byPid = newByPid, latestBySlice = newLatestBySlice, oldestTimestamp = newOldestTimestamp)
       }
     }
+
+    def contains(pid: Pid): Boolean =
+      byPid.contains(pid)
 
     def isDuplicate(record: Record): Boolean = {
       byPid.get(record.pid) match {
@@ -127,27 +116,21 @@ private[projection] object DynamoDBOffsetStore {
       }
     }
 
+    def recordsWithTimestamp(timestamp: Instant): IndexedSeq[Record] =
+      byPid.valuesIterator.collect { case r if r.timestamp == timestamp => r }.toVector
+
     def window: JDuration =
       JDuration.between(oldestTimestamp, latestTimestamp)
 
     private lazy val sortedByTimestamp: Vector[Record] = byPid.valuesIterator.toVector.sortBy(_.timestamp)
 
-    lazy val latestBySlice: Vector[Record] = {
-      val builder = scala.collection.mutable.Map[Int, Record]()
-      sortedByTimestamp.reverseIterator.foreach { record =>
-        if (!builder.contains(record.slice))
-          builder.update(record.slice, record)
-      }
-      builder.values.toVector
-    }
-
     def evict(until: Instant, keepNumberOfEntries: Int): State = {
       if (oldestTimestamp.isBefore(until) && size > keepNumberOfEntries) {
-        val newState = State(
+        val newState = State(latestBySlice).add(
           sortedByTimestamp
             .take(size - keepNumberOfEntries)
             .filterNot(_.timestamp.isBefore(until)) ++ sortedByTimestamp
-            .takeRight(keepNumberOfEntries) ++ latestBySlice)
+            .takeRight(keepNumberOfEntries))
         newState.copy(sizeAfterEvict = newState.size)
       } else
         this
@@ -193,6 +176,13 @@ private[projection] class DynamoDBOffsetStore(
 
   private val persistenceExt = Persistence(system)
 
+  private val (minSlice: Int, maxSlice: Int) = sourceProvider match {
+    case Some(s) => s.minSlice -> s.maxSlice
+    case None    => 0 -> (persistenceExt.numberOfSlices - 1)
+  }
+
+  private val dao = new OffsetStoreDao(system, settings, projectionId, client)
+
   private val evictWindow = settings.timeWindow.plus(settings.evictInterval)
 
   private[projection] implicit val executionContext: ExecutionContext = system.executionContext
@@ -231,17 +221,19 @@ private[projection] class DynamoDBOffsetStore(
     inflight.get()
 
   def getOffset[Offset](): Future[Option[Offset]] = {
-    getState().latestOffset match {
-      case Some(t) => Future.successful(Some(t.asInstanceOf[Offset]))
-      case None    => readOffset()
-    }
+    // FIXME somewhat unclear if this should be latest or by slice
+//    getState().latestOffset match {
+//      case Some(t) => Future.successful(Some(t.asInstanceOf[Offset]))
+//      case None    => readOffset()
+//    }
+    ???
   }
 
   def readOffset[Offset](): Future[Option[Offset]] = {
     // look for TimestampOffset first since that is used by akka-persistence-dynamodb,
     // and then fall back to the other more primitive offset types
     sourceProvider match {
-      case Some(_) =>
+      case Some(s) =>
         readTimestampOffset().map {
           case Some(t) => Some(t.asInstanceOf[Offset])
           case None    => None
@@ -253,24 +245,81 @@ private[projection] class DynamoDBOffsetStore(
   }
 
   private def readTimestampOffset(): Future[Option[TimestampOffset]] = {
-    // FIXME
-    clearInflight()
-    ???
+    val oldState = state.get()
+    // retrieve latest timestamp for each slice, and use the earliest
+    val futTimestamps =
+      (minSlice to maxSlice).map(slice => dao.latestTimestamp(slice).map(optTimestamp => slice -> optTimestamp))
+    val latestBySliceFut = Future.sequence(futTimestamps).map(_.collect { case (slice, Some(ts)) => slice -> ts }.toMap)
+    latestBySliceFut.map { latestBySlice =>
+      val newState = State(latestBySlice)
+      logger.debugN(
+        "readTimestampOffset state with [{}] persistenceIds, oldest [{}], latest [{}]",
+        newState.byPid.size,
+        newState.oldestTimestamp,
+        newState.latestTimestamp)
+      if (!state.compareAndSet(oldState, newState))
+        throw new IllegalStateException("Unexpected concurrent modification of state from readOffset.")
+      clearInflight()
+      if (latestBySlice.isEmpty) {
+        logger.debug("readTimestampOffset no stored offset")
+        None
+      } else {
+        // FIXME r2dbc is only using earliest when moreThanOneProjectionKey.
+        // When a projection is restarted and there has not been any scaling. We could store the
+        // projectionKey together with the timestamp by slice to have the same here.
+        val earliest = latestBySlice.valuesIterator.min
+        if (logger.isDebugEnabled)
+          logger.debug(
+            "readTimestampOffset earliest slice [{}], latest slice [{}]",
+            latestBySlice.minBy(_._1),
+            latestBySlice.maxBy(_._1))
+
+        // FIXME populating seen like this is fruitless, since no pids have been loaded to the
+        // newState. Shall we just skip the seen, otherwise it would have to be stored together with
+        // the latestBySlice timestamp
+        // not important to reconstruct the right `seen`, will be filtered as duplicates by offset store
+        // val seen = newState.recordsWithTimestamp(earliest).iterator.map(r => r.pid -> r.seqNr).toMap
+        Some(TimestampOffset(earliest, Map.empty))
+      }
+    }
   }
 
-  private def moreThanOneProjectionKey(recordsWithKey: immutable.IndexedSeq[RecordWithProjectionKey]): Boolean = {
-    if (recordsWithKey.isEmpty)
-      false
+  private def load(pid: Pid): Future[Done] = {
+    val oldState = state.get()
+    val slice = persistenceExt.sliceForPersistenceId(pid)
+    dao.load(slice, pid).map {
+      case Some(record) =>
+        val newState = oldState.add(Vector(record))
+        if (!state.compareAndSet(oldState, newState))
+          throw new IllegalStateException("Unexpected concurrent modification of state from load.")
+        Done
+      case None => Done
+    }
+  }
+
+  private def load(pids: IndexedSeq[Pid]): Future[Done] = {
+    val oldState = state.get()
+    val pidsToLoad = pids.filterNot(oldState.contains)
+    if (pidsToLoad.isEmpty)
+      FutureDone
     else {
-      val key = recordsWithKey.head.projectionKey
-      recordsWithKey.exists(_.projectionKey != key)
+      val loadedRecords = pidsToLoad.map { pid =>
+        val slice = persistenceExt.sliceForPersistenceId(pid)
+        dao.load(slice, pid)
+      }
+      Future.sequence(loadedRecords).map { records =>
+        val newState = oldState.add(records.flatten)
+        if (!state.compareAndSet(oldState, newState))
+          throw new IllegalStateException("Unexpected concurrent modification of state from load.")
+        Done
+      }
     }
   }
 
   def saveOffset(offset: OffsetPidSeqNr): Future[Done] =
     saveOffsets(Vector(offset))
 
-  def saveOffsets(offsets: immutable.IndexedSeq[OffsetPidSeqNr]): Future[Done] = {
+  def saveOffsets(offsets: IndexedSeq[OffsetPidSeqNr]): Future[Done] = {
     if (offsets.isEmpty)
       FutureDone
     else if (offsets.head.offset.isInstanceOf[TimestampOffset]) {
@@ -290,58 +339,67 @@ private[projection] class DynamoDBOffsetStore(
     }
   }
 
-  private def saveTimestampOffsets(records: immutable.IndexedSeq[Record]): Future[Done] = {
-    val oldState = state.get()
-    val filteredRecords = {
-      if (records.size <= 1)
-        records.filterNot(oldState.isDuplicate)
-      else {
-        // use last record for each pid
-        records
-          .groupBy(_.pid)
-          .valuesIterator
-          .collect {
-            case recordsByPid if !oldState.isDuplicate(recordsByPid.last) => recordsByPid.last
-          }
-          .toVector
+  private def saveTimestampOffsets(records: IndexedSeq[Record]): Future[Done] = {
+    load(records.map(_.pid)).flatMap { _ =>
+      val oldState = state.get()
+      val filteredRecords = {
+        if (records.size <= 1)
+          records.filterNot(oldState.isDuplicate)
+        else {
+          // use last record for each pid
+          records
+            .groupBy(_.pid)
+            .valuesIterator
+            .collect {
+              case recordsByPid if !oldState.isDuplicate(recordsByPid.last) => recordsByPid.last
+            }
+            .toVector
+        }
       }
-    }
-    if (filteredRecords.isEmpty) {
-      FutureDone
-    } else {
-      val newState = oldState.add(filteredRecords)
+      if (filteredRecords.isEmpty) {
+        FutureDone
+      } else {
+        val newState = oldState.add(filteredRecords)
 
-      // accumulate some more than the timeWindow before evicting, and at least 10% increase of size
-      // for testing keepNumberOfEntries = 0 is used
-      val evictThresholdReached =
-        if (settings.keepNumberOfEntries == 0) true else newState.size > (newState.sizeAfterEvict * 1.1).toInt
-      val evictedNewState =
-        if (newState.size > settings.keepNumberOfEntries && evictThresholdReached && newState.window
-            .compareTo(evictWindow) > 0) {
-          val evictUntil = newState.latestTimestamp.minus(settings.timeWindow)
-          val s = newState.evict(evictUntil, settings.keepNumberOfEntries)
-          logger.debugN(
-            "Evicted [{}] records until [{}], keeping [{}] records. Latest [{}].",
-            newState.size - s.size,
-            evictUntil,
-            s.size,
-            newState.latestTimestamp)
-          s
-        } else
-          newState
+        // accumulate some more than the timeWindow before evicting, and at least 10% increase of size
+        // for testing keepNumberOfEntries = 0 is used
+        val evictThresholdReached =
+          if (settings.keepNumberOfEntries == 0) true else newState.size > (newState.sizeAfterEvict * 1.1).toInt
+        val evictedNewState =
+          if (newState.size > settings.keepNumberOfEntries && evictThresholdReached && newState.window
+              .compareTo(evictWindow) > 0) {
+            val evictUntil = newState.latestTimestamp.minus(settings.timeWindow)
+            val s = newState.evict(evictUntil, settings.keepNumberOfEntries)
+            logger.debugN(
+              "Evicted [{}] records until [{}], keeping [{}] records. Latest [{}].",
+              newState.size - s.size,
+              evictUntil,
+              s.size,
+              newState.latestTimestamp)
+            s
+          } else
+            newState
 
-      // FIXME
-      val offsetInserts: Future[Done] = ???
+        // FIXME we probably don't have to store the latest timestamps all the time, but can
+        // accumulate some changes and flush on size/time.
+        val changedLatestBySlice = evictedNewState.latestBySlice.filter { case (slice, timestamp) =>
+          timestamp != oldState.latestBySlice.getOrElse(slice, Instant.EPOCH)
+        }
 
-      offsetInserts.map { _ =>
-        if (state.compareAndSet(oldState, evictedNewState))
-          cleanupInflight(evictedNewState)
-        else
-          throw new IllegalStateException("Unexpected concurrent modification of state from saveOffset.")
-        Done
+        for {
+          _ <- dao.storeSequenceNumbers(filteredRecords)
+          _ <- if (changedLatestBySlice.isEmpty) FutureDone else dao.storeLatestTimestamps(changedLatestBySlice)
+        } yield {
+          if (state.compareAndSet(oldState, evictedNewState))
+            cleanupInflight(evictedNewState)
+          else
+            throw new IllegalStateException("Unexpected concurrent modification of state from saveOffset.")
+          Done
+        }
       }
     }
   }
+
   @tailrec private def cleanupInflight(newState: State): Unit = {
     val currentInflight = getInflight()
     val newInflight =
@@ -369,14 +427,21 @@ private[projection] class DynamoDBOffsetStore(
   /**
    * The stored sequence number for a persistenceId, or 0 if unknown persistenceId.
    */
-  def storedSeqNr(pid: Pid): SeqNr =
+  def storedSeqNr(pid: Pid): Future[SeqNr] = {
     getState().byPid.get(pid) match {
-      case Some(record) => record.seqNr
-      case None         => 0L
+      case Some(record) => Future.successful(record.seqNr)
+      case None =>
+        val slice = persistenceExt.sliceForPersistenceId(pid)
+        dao.load(slice, pid).map {
+          case Some(record) => record.seqNr
+          case None         => 0L
+        }
     }
+  }
 
-  def validateAll[Envelope](envelopes: immutable.Seq[Envelope]): Future[immutable.Seq[(Envelope, Validation)]] = {
+  def validateAll[Envelope](envelopes: Seq[Envelope]): Future[Seq[(Envelope, Validation)]] = {
     import Validation._
+
     envelopes
       .foldLeft(Future.successful((getInflight(), Vector.empty[(Envelope, Validation)]))) { (acc, envelope) =>
         acc.flatMap { case (inflight, filteredEnvelopes) =>
@@ -415,130 +480,138 @@ private[projection] class DynamoDBOffsetStore(
     import Validation._
     val pid = recordWithOffset.record.pid
     val seqNr = recordWithOffset.record.seqNr
-    val currentState = getState()
 
-    val duplicate = getState().isDuplicate(recordWithOffset.record)
+    // FIXME load is also updating the state, is validate guaranteed to not be called concurrently?
+    load(pid).flatMap { _ =>
+      val currentState = getState()
 
-    if (duplicate) {
-      logger.trace("Filtering out duplicate sequence number [{}] for pid [{}]", seqNr, pid)
-      FutureDuplicate
-    } else if (recordWithOffset.strictSeqNr) {
-      // strictSeqNr == true is for event sourced
-      val prevSeqNr = currentInflight.getOrElse(pid, currentState.byPid.get(pid).map(_.seqNr).getOrElse(0L))
+      val duplicate = currentState.isDuplicate(recordWithOffset.record)
 
-      def logUnexpected(): Unit = {
-        if (recordWithOffset.fromPubSub)
-          logger.debugN(
-            "Rejecting pub-sub envelope, unexpected sequence number [{}] for pid [{}], previous sequence number [{}]. Offset: {}",
-            seqNr,
-            pid,
-            prevSeqNr,
-            recordWithOffset.offset)
-        else if (!recordWithOffset.fromBacktracking)
-          logger.debugN(
-            "Rejecting unexpected sequence number [{}] for pid [{}], previous sequence number [{}]. Offset: {}",
-            seqNr,
-            pid,
-            prevSeqNr,
-            recordWithOffset.offset)
-        else
-          logger.warnN(
-            "Rejecting unexpected sequence number [{}] for pid [{}], previous sequence number [{}]. Offset: {}",
-            seqNr,
-            pid,
-            prevSeqNr,
-            recordWithOffset.offset)
-      }
+      if (duplicate) {
+        logger.trace("Filtering out duplicate sequence number [{}] for pid [{}]", seqNr, pid)
+        FutureDuplicate
+      } else if (recordWithOffset.strictSeqNr) {
+        // strictSeqNr == true is for event sourced
+        val prevSeqNr = currentInflight.getOrElse(pid, currentState.byPid.get(pid).map(_.seqNr).getOrElse(0L))
 
-      def logUnknown(): Unit = {
-        if (recordWithOffset.fromPubSub) {
-          logger.debugN(
-            "Rejecting pub-sub envelope, unknown sequence number [{}] for pid [{}] (might be accepted later): {}",
-            seqNr,
-            pid,
-            recordWithOffset.offset)
-        } else if (!recordWithOffset.fromBacktracking) {
-          // This may happen rather frequently when using `publish-events`, after reconnecting and such.
-          logger.debugN(
-            "Rejecting unknown sequence number [{}] for pid [{}] (might be accepted later): {}",
-            seqNr,
-            pid,
-            recordWithOffset.offset)
-        } else {
-          logger.warnN(
-            "Rejecting unknown sequence number [{}] for pid [{}]. Offset: {}",
-            seqNr,
-            pid,
-            recordWithOffset.offset)
+        def logUnexpected(): Unit = {
+          if (recordWithOffset.fromPubSub)
+            logger.debugN(
+              "Rejecting pub-sub envelope, unexpected sequence number [{}] for pid [{}], previous sequence number [{}]. Offset: {}",
+              seqNr,
+              pid,
+              prevSeqNr,
+              recordWithOffset.offset)
+          else if (!recordWithOffset.fromBacktracking)
+            logger.debugN(
+              "Rejecting unexpected sequence number [{}] for pid [{}], previous sequence number [{}]. Offset: {}",
+              seqNr,
+              pid,
+              prevSeqNr,
+              recordWithOffset.offset)
+          else
+            logger.warnN(
+              "Rejecting unexpected sequence number [{}] for pid [{}], previous sequence number [{}]. Offset: {}",
+              seqNr,
+              pid,
+              prevSeqNr,
+              recordWithOffset.offset)
         }
-      }
 
-      if (prevSeqNr > 0) {
-        // expecting seqNr to be +1 of previously known
-        val ok = seqNr == prevSeqNr + 1
+        def logUnknown(): Unit = {
+          if (recordWithOffset.fromPubSub) {
+            logger.debugN(
+              "Rejecting pub-sub envelope, unknown sequence number [{}] for pid [{}] (might be accepted later): {}",
+              seqNr,
+              pid,
+              recordWithOffset.offset)
+          } else if (!recordWithOffset.fromBacktracking) {
+            // This may happen rather frequently when using `publish-events`, after reconnecting and such.
+            logger.debugN(
+              "Rejecting unknown sequence number [{}] for pid [{}] (might be accepted later): {}",
+              seqNr,
+              pid,
+              recordWithOffset.offset)
+          } else {
+            logger.warnN(
+              "Rejecting unknown sequence number [{}] for pid [{}]. Offset: {}",
+              seqNr,
+              pid,
+              recordWithOffset.offset)
+          }
+        }
+
+        if (prevSeqNr > 0) {
+          // expecting seqNr to be +1 of previously known
+          val ok = seqNr == prevSeqNr + 1
+          if (ok) {
+            FutureAccepted
+          } else if (seqNr <= currentInflight.getOrElse(pid, 0L)) {
+            // currentInFlight contains those that have been processed or about to be processed in Flow,
+            // but offset not saved yet => ok to handle as duplicate
+            FutureDuplicate
+          } else if (recordWithOffset.fromSnapshot) {
+            // snapshots will mean we are starting from some arbitrary offset after last seen offset
+            FutureAccepted
+          } else if (!recordWithOffset.fromBacktracking) {
+            logUnexpected()
+            FutureRejectedSeqNr
+          } else {
+            logUnexpected()
+            // This will result in projection restart (with normal configuration)
+            FutureRejectedBacktrackingSeqNr
+          }
+        } else if (seqNr == 1) {
+          // always accept first event if no other event for that pid has been seen
+          FutureAccepted
+        } else if (recordWithOffset.fromSnapshot) {
+          // always accept starting from snapshots when there was no previous event seen
+          FutureAccepted
+        } else {
+          // Haven't see seen this pid within the time window. Since events can be missed
+          // when read at the tail we will only accept it if the event with previous seqNr has timestamp
+          // before the time window of the offset store.
+          // Backtracking will emit missed event again.
+          timestampOf(pid, seqNr - 1).map {
+            case Some(previousTimestamp) =>
+              val before = currentState.latestTimestamp.minus(settings.timeWindow)
+              if (previousTimestamp.isBefore(before)) {
+                logger.debugN(
+                  "Accepting envelope with pid [{}], seqNr [{}], where previous event timestamp [{}] " +
+                  "is before time window [{}].",
+                  pid,
+                  seqNr,
+                  previousTimestamp,
+                  before)
+                Accepted
+              } else if (!recordWithOffset.fromBacktracking) {
+                logUnknown()
+                RejectedSeqNr
+              } else {
+                logUnknown()
+                // This will result in projection restart (with normal configuration)
+                RejectedBacktrackingSeqNr
+              }
+            case None =>
+              // previous not found, could have been deleted
+              Accepted
+          }
+        }
+      } else {
+        // strictSeqNr == false is for durable state where each revision might not be visible
+        val prevSeqNr = currentInflight.getOrElse(pid, currentState.byPid.get(pid).map(_.seqNr).getOrElse(0L))
+        val ok = seqNr > prevSeqNr
+
         if (ok) {
           FutureAccepted
-        } else if (seqNr <= currentInflight.getOrElse(pid, 0L)) {
-          // currentInFlight contains those that have been processed or about to be processed in Flow,
-          // but offset not saved yet => ok to handle as duplicate
-          FutureDuplicate
-        } else if (recordWithOffset.fromSnapshot) {
-          // snapshots will mean we are starting from some arbitrary offset after last seen offset
-          FutureAccepted
-        } else if (!recordWithOffset.fromBacktracking) {
-          logUnexpected()
-          FutureRejectedSeqNr
         } else {
-          logUnexpected()
-          // This will result in projection restart (with normal configuration)
-          FutureRejectedBacktrackingSeqNr
+          logger.traceN(
+            "Filtering out earlier revision [{}] for pid [{}], previous revision [{}]",
+            seqNr,
+            pid,
+            prevSeqNr)
+          FutureDuplicate
         }
-      } else if (seqNr == 1) {
-        // always accept first event if no other event for that pid has been seen
-        FutureAccepted
-      } else if (recordWithOffset.fromSnapshot) {
-        // always accept starting from snapshots when there was no previous event seen
-        FutureAccepted
-      } else {
-        // Haven't see seen this pid within the time window. Since events can be missed
-        // when read at the tail we will only accept it if the event with previous seqNr has timestamp
-        // before the time window of the offset store.
-        // Backtracking will emit missed event again.
-        timestampOf(pid, seqNr - 1).map {
-          case Some(previousTimestamp) =>
-            val before = currentState.latestTimestamp.minus(settings.timeWindow)
-            if (previousTimestamp.isBefore(before)) {
-              logger.debugN(
-                "Accepting envelope with pid [{}], seqNr [{}], where previous event timestamp [{}] " +
-                "is before time window [{}].",
-                pid,
-                seqNr,
-                previousTimestamp,
-                before)
-              Accepted
-            } else if (!recordWithOffset.fromBacktracking) {
-              logUnknown()
-              RejectedSeqNr
-            } else {
-              logUnknown()
-              // This will result in projection restart (with normal configuration)
-              RejectedBacktrackingSeqNr
-            }
-          case None =>
-            // previous not found, could have been deleted
-            Accepted
-        }
-      }
-    } else {
-      // strictSeqNr == false is for durable state where each revision might not be visible
-      val prevSeqNr = currentInflight.getOrElse(pid, currentState.byPid.get(pid).map(_.seqNr).getOrElse(0L))
-      val ok = seqNr > prevSeqNr
-
-      if (ok) {
-        FutureAccepted
-      } else {
-        logger.traceN("Filtering out earlier revision [{}] for pid [{}], previous revision [{}]", seqNr, pid, prevSeqNr)
-        FutureDuplicate
       }
     }
   }
@@ -554,7 +627,7 @@ private[projection] class DynamoDBOffsetStore(
     }
   }
 
-  @tailrec final def addInflights[Envelope](envelopes: immutable.Seq[Envelope]): Unit = {
+  @tailrec final def addInflights[Envelope](envelopes: Seq[Envelope]): Unit = {
     val currentInflight = getInflight()
     val entries = envelopes.iterator.map(createRecordWithOffset).collect { case Some(r) =>
       r.record.pid -> r.record.seqNr

--- a/projection/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb.internal
+
+import java.util.{ HashMap => JHashMap }
+import java.time.Instant
+import java.util.Collections
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.persistence.dynamodb.internal.InstantFactory
+import akka.projection.ProjectionId
+import akka.projection.dynamodb.DynamoDBProjectionSettings
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Record
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest
+import software.amazon.awssdk.services.dynamodb.model.PutRequest
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[projection] object OffsetStoreDao {
+  private val log: Logger = LoggerFactory.getLogger(classOf[OffsetStoreDao])
+
+  object OffsetStoreAttributes {
+    // FIXME should attribute names be shorter?
+    val Pid = "pid"
+    val SeqNr = "seq_nr"
+    val NameSlice = "name_slice"
+    val Timestamp = "ts"
+
+    // FIXME empty string not allowed
+    val timestampBySlicePid = AttributeValue.fromS("_")
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[projection] class OffsetStoreDao(
+    system: ActorSystem[_],
+    settings: DynamoDBProjectionSettings,
+    projectionId: ProjectionId,
+    client: DynamoDbAsyncClient) {
+  import OffsetStoreDao.log
+  import system.executionContext
+
+  private def nameSlice(slice: Int): String = s"${projectionId.name}-$slice"
+
+  def latestTimestamp(slice: Int): Future[Option[Instant]] = {
+    import OffsetStoreDao.OffsetStoreAttributes._
+    val expressionAttributeValues =
+      Map(":nameSlice" -> AttributeValue.fromS(nameSlice(slice)), ":pid" -> timestampBySlicePid).asJava
+
+    val req = QueryRequest.builder
+      .tableName(settings.timestampOffsetTable)
+      .consistentRead(false) // not necessary to read latest, can start at earlier time
+      .keyConditionExpression(s"$NameSlice = :nameSlice AND $Pid = :pid")
+      .expressionAttributeValues(expressionAttributeValues)
+      .projectionExpression(Timestamp)
+      .build()
+
+    client.query(req).asScala.map { response =>
+      val items = response.items()
+      if (items.isEmpty)
+        None
+      else {
+        val timestampMicros = items.get(0).get(Timestamp).n().toLong
+        Some(InstantFactory.fromEpochMicros(timestampMicros))
+      }
+    }
+  }
+
+  def storeLatestTimestamps(timestampsBySlice: Map[Int, Instant]): Future[Done] = {
+    import OffsetStoreDao.OffsetStoreAttributes._
+
+    // FIXME upper limit on number of writes in a batch, split up
+
+    val writeItems =
+      timestampsBySlice
+        .map { case (slice, timestamp) =>
+          val attributes = new JHashMap[String, AttributeValue]
+          attributes.put(NameSlice, AttributeValue.fromS(nameSlice(slice)))
+          attributes.put(Pid, timestampBySlicePid)
+          val timestampMicros = InstantFactory.toEpochMicros(timestamp)
+          attributes.put(Timestamp, AttributeValue.fromN(timestampMicros.toString))
+
+          WriteRequest.builder
+            .putRequest(
+              PutRequest
+                .builder()
+                .item(attributes)
+                .build())
+            .build()
+        }
+        .toVector
+        .asJava
+
+    val req = BatchWriteItemRequest
+      .builder()
+      .requestItems(Collections.singletonMap(settings.timestampOffsetTable, writeItems))
+      .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+      .build()
+
+    val result = client.batchWriteItem(req).asScala
+
+    if (log.isDebugEnabled()) {
+      result.foreach { response =>
+        log.debug(
+          "Wrote latest timestamps for [{}] slices, consumed [{}] WCU",
+          timestampsBySlice.size,
+          response.consumedCapacity.iterator.asScala.map(_.capacityUnits.doubleValue()).sum)
+      }
+    }
+
+    result.map(_ => Done)(ExecutionContexts.parasitic)
+  }
+
+  def storeSequenceNumbers(records: IndexedSeq[Record]): Future[Done] = {
+    import OffsetStoreDao.OffsetStoreAttributes._
+
+    // FIXME upper limit on number of writes in a batch, split up
+
+    val writeItems =
+      records
+        .map { case Record(slice, pid, seqNr, timestamp) =>
+          val attributes = new JHashMap[String, AttributeValue]
+          attributes.put(NameSlice, AttributeValue.fromS(nameSlice(slice)))
+          attributes.put(Pid, AttributeValue.fromS(pid))
+          attributes.put(SeqNr, AttributeValue.fromN(seqNr.toString))
+          val timestampMicros = InstantFactory.toEpochMicros(timestamp)
+          attributes.put(Timestamp, AttributeValue.fromN(timestampMicros.toString))
+
+          WriteRequest.builder
+            .putRequest(
+              PutRequest
+                .builder()
+                .item(attributes)
+                .build())
+            .build()
+        }
+        .toVector
+        .asJava
+
+    val req = BatchWriteItemRequest
+      .builder()
+      .requestItems(Collections.singletonMap(settings.timestampOffsetTable, writeItems))
+      .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+      .build()
+
+    val result = client.batchWriteItem(req).asScala
+
+    if (log.isDebugEnabled()) {
+      result.foreach { response =>
+        log.debug(
+          "Wrote [{}] sequence numbers, consumed [{}] WCU",
+          records.size,
+          response.consumedCapacity.iterator.asScala.map(_.capacityUnits.doubleValue()).sum)
+      }
+    }
+
+    result.map(_ => Done)(ExecutionContexts.parasitic)
+  }
+
+  def load(slice: Int, pid: String): Future[Option[Record]] = {
+    import OffsetStoreDao.OffsetStoreAttributes._
+    val expressionAttributeValues =
+      Map(":nameSlice" -> AttributeValue.fromS(nameSlice(slice)), ":pid" -> AttributeValue.fromS(pid)).asJava
+
+    val req = QueryRequest.builder
+      .tableName(settings.timestampOffsetTable)
+      .consistentRead(true)
+      .keyConditionExpression(s"$NameSlice = :nameSlice AND $Pid = :pid")
+      .expressionAttributeValues(expressionAttributeValues)
+      .projectionExpression(s"$SeqNr, $Timestamp")
+      .build()
+
+    client.query(req).asScala.map { response =>
+      val items = response.items()
+      if (items.isEmpty)
+        None
+      else {
+        val item = items.get(0)
+        val seqNr = item.get(SeqNr).n().toLong
+        val timestampMicros = item.get(Timestamp).n().toLong
+        val timestamp = InstantFactory.fromEpochMicros(timestampMicros)
+        Some(DynamoDBOffsetStore.Record(slice, pid, seqNr, timestamp))
+      }
+    }
+  }
+}

--- a/projection/src/main/scala/akka/projection/dynamodb/scaladsl/DynamoDBProjection.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/scaladsl/DynamoDBProjection.scala
@@ -4,7 +4,6 @@
 
 package akka.projection.dynamodb.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 import akka.Done

--- a/projection/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb
+
+import java.time.Instant
+
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Pid
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Record
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.SeqNr
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.State
+import org.scalatest.TestSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers {
+
+  def createRecord(pid: Pid, seqNr: SeqNr, timestamp: Instant): Record = {
+    Record(slice(pid), pid, seqNr, timestamp)
+  }
+
+  def slice(pid: Pid): Int = math.abs(pid.hashCode % 1024)
+
+  "DynamoDBOffsetStore.State" should {
+    "add records and keep track of pids and latest offset" in {
+      val t0 = TestClock.nowMillis().instant()
+      val state1 = State.empty
+        .add(
+          Vector(
+            createRecord("p1", 1, t0),
+            createRecord("p1", 2, t0.plusMillis(1)),
+            createRecord("p1", 3, t0.plusMillis(2))))
+      state1.byPid("p1").seqNr shouldBe 3L
+      state1.latestBySlice(slice("p1")) shouldBe t0.plusMillis(2)
+      state1.latestTimestamp shouldBe t0.plusMillis(2)
+      state1.oldestTimestamp shouldBe t0
+
+      val state2 = state1.add(Vector(createRecord("p2", 2, t0.plusMillis(1))))
+      state2.byPid("p1").seqNr shouldBe 3L
+      state2.byPid("p2").seqNr shouldBe 2L
+      state2.latestBySlice(slice("p2")) shouldBe t0.plusMillis(1)
+      // latest not updated because timestamp of p2 was before latest
+      state2.latestTimestamp shouldBe t0.plusMillis(2)
+      state2.oldestTimestamp shouldBe t0
+
+      val state3 = state2.add(Vector(createRecord("p3", 10, t0.plusMillis(3))))
+      state3.byPid("p1").seqNr shouldBe 3L
+      state3.byPid("p2").seqNr shouldBe 2L
+      state3.byPid("p3").seqNr shouldBe 10L
+      state3.latestBySlice(slice("p3")) shouldBe t0.plusMillis(3)
+      state3.latestTimestamp shouldBe t0.plusMillis(3)
+      state3.oldestTimestamp shouldBe t0
+    }
+
+    "evict old" in {
+      // these pids have the same slice 645, otherwise it will keep one for each slice
+      val p1 = "p500"
+      val p2 = "p621"
+      val p3 = "p742"
+      val p4 = "p863"
+      val p5 = "p984"
+
+      val t0 = TestClock.nowMillis().instant()
+      val state1 = State.empty
+        .add(
+          Vector(
+            createRecord(p1, 1, t0),
+            createRecord(p2, 2, t0.plusMillis(1)),
+            createRecord(p3, 3, t0.plusMillis(2)),
+            createRecord(p4, 4, t0.plusMillis(3)),
+            createRecord(p5, 5, t0.plusMillis(4))))
+      state1.oldestTimestamp shouldBe t0
+      state1.byPid
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p5 -> 5L)
+
+      val state2 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 1)
+      state2.oldestTimestamp shouldBe t0.plusMillis(2)
+      state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p3 -> 3L, p4 -> 4L, p5 -> 5L)
+
+      // keep all
+      state1.evict(t0.plusMillis(2), keepNumberOfEntries = 100) shouldBe state1
+
+      // keep 4
+      val state3 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 4)
+      state3.oldestTimestamp shouldBe t0.plusMillis(1)
+      state3.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p5 -> 5L)
+    }
+
+    "find duplicate" in {
+      val t0 = TestClock.nowMillis().instant()
+      val state =
+        State.empty.add(
+          Vector(
+            createRecord("p1", 1, t0),
+            createRecord("p2", 2, t0.plusMillis(1)),
+            createRecord("p3", 3, t0.plusMillis(2))))
+      state.isDuplicate(createRecord("p1", 1, t0)) shouldBe true
+      state.isDuplicate(createRecord("p1", 2, t0.plusMillis(10))) shouldBe false
+      state.isDuplicate(createRecord("p2", 1, t0)) shouldBe true
+      state.isDuplicate(createRecord("p4", 4, t0.plusMillis(10))) shouldBe false
+    }
+  }
+}

--- a/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -1,0 +1,954 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb
+
+import java.time.Instant
+import java.time.{ Duration => JDuration }
+import java.util.UUID
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.dynamodb.internal.EnvelopeOrigin
+import akka.persistence.query.Offset
+import akka.persistence.query.TimestampOffset
+import akka.persistence.query.UpdatedDurableState
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.query.typed.scaladsl.EventTimestampQuery
+import akka.persistence.query.typed.scaladsl.LoadEventQuery
+import akka.persistence.typed.PersistenceId
+import akka.projection.BySlicesSourceProvider
+import akka.projection.ProjectionId
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Pid
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.SeqNr
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.Accepted
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.Duplicate
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.RejectedBacktrackingSeqNr
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.RejectedSeqNr
+import akka.projection.dynamodb.internal.OffsetPidSeqNr
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.slf4j.LoggerFactory
+
+object DynamoDBTimestampOffsetStoreSpec {
+  class TestTimestampSourceProvider(override val minSlice: Int, override val maxSlice: Int, clock: TestClock)
+      extends BySlicesSourceProvider
+      with EventTimestampQuery
+      with LoadEventQuery {
+
+    override def timestampOf(persistenceId: String, sequenceNr: SeqNr): Future[Option[Instant]] =
+      Future.successful(Some(clock.instant()))
+
+    override def loadEnvelope[Event](persistenceId: String, sequenceNr: SeqNr): Future[EventEnvelope[Event]] =
+      throw new IllegalStateException("loadEvent shouldn't be used here")
+  }
+}
+
+class DynamoDBTimestampOffsetStoreSpec
+    extends ScalaTestWithActorTestKit(
+      ConfigFactory
+        .parseString("""
+    # to be able to test eviction
+    akka.projection.dynamodb.offset-store.keep-number-of-entries = 0
+    """).withFallback(TestConfig.config))
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+  import DynamoDBTimestampOffsetStoreSpec.TestTimestampSourceProvider
+
+  override def typedSystem: ActorSystem[_] = system
+
+  private val clock = TestClock.nowMicros()
+  def tick(): Unit = clock.tick(JDuration.ofMillis(1))
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private def createOffsetStore(
+      projectionId: ProjectionId,
+      customSettings: DynamoDBProjectionSettings = settings,
+      eventTimestampQueryClock: TestClock = clock) =
+    new DynamoDBOffsetStore(
+      projectionId,
+      Some(new TestTimestampSourceProvider(0, persistenceExt.numberOfSlices - 1, eventTimestampQueryClock)),
+      system,
+      customSettings,
+      client)
+
+  def createEnvelope(pid: Pid, seqNr: SeqNr, timestamp: Instant, event: String): EventEnvelope[String] = {
+    val entityType = PersistenceId.extractEntityType(pid)
+    val slice = persistenceExt.sliceForPersistenceId(pid)
+    EventEnvelope(
+      TimestampOffset(timestamp, timestamp.plusMillis(1000), Map(pid -> seqNr)),
+      pid,
+      seqNr,
+      event,
+      timestamp.toEpochMilli,
+      entityType,
+      slice)
+  }
+
+  def backtrackingEnvelope(env: EventEnvelope[String]): EventEnvelope[String] =
+    new EventEnvelope[String](
+      env.offset,
+      env.persistenceId,
+      env.sequenceNr,
+      eventOption = None,
+      env.timestamp,
+      env.eventMetadata,
+      env.entityType,
+      env.slice,
+      env.filtered,
+      source = EnvelopeOrigin.SourceBacktracking)
+
+  def filteredEnvelope(env: EventEnvelope[String]): EventEnvelope[String] =
+    new EventEnvelope[String](
+      env.offset,
+      env.persistenceId,
+      env.sequenceNr,
+      env.eventOption,
+      env.timestamp,
+      env.eventMetadata,
+      env.entityType,
+      env.slice,
+      filtered = true,
+      env.source)
+
+  def createUpdatedDurableState(
+      pid: Pid,
+      revision: SeqNr,
+      timestamp: Instant,
+      state: String): UpdatedDurableState[String] =
+    new UpdatedDurableState(
+      pid,
+      revision,
+      state,
+      TimestampOffset(timestamp, timestamp.plusMillis(1000), Map(pid -> revision)),
+      timestamp.toEpochMilli)
+
+  def slice(pid: String): Int =
+    persistenceExt.sliceForPersistenceId(pid)
+
+  // FIXME seen not reconstructed
+  private def withoutSeen(offset: TimestampOffset): TimestampOffset =
+    TimestampOffset(offset.timestamp, offset.readTimestamp, Map.empty)
+  private def withoutSeen(offset: Any): TimestampOffset =
+    withoutSeen(offset.asInstanceOf[TimestampOffset])
+
+  s"The DynamoDBOffsetStore for TimestampOffset" must {
+
+    "save TimestampOffset with one entry" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      readOffset1.futureValue shouldBe Some(withoutSeen(offset1))
+      offsetStore.getState().latestBySlice(slice("p1")) shouldBe offset1.timestamp
+      offsetStore.storedSeqNr("p1").futureValue shouldBe 3L
+
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 4L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 4L)).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      readOffset2.futureValue shouldBe Some(withoutSeen(offset2)) // yep, saveOffset overwrites previous
+      offsetStore.getState().latestBySlice(slice("p1")) shouldBe offset2.timestamp
+      offsetStore.storedSeqNr("p1").futureValue shouldBe 4L
+    }
+
+    "save TimestampOffset with several seen entries" in {
+      // FIXME seen not reconstructed
+      pending
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      val expectedOffset1 = TimestampOffset(offset1.timestamp, offset1.readTimestamp, Map("p1" -> 3L))
+      readOffset1.futureValue shouldBe Some(expectedOffset1)
+
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 4L, "p3" -> 6L, "p4" -> 9L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p3", 6L)).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      val expectedOffset2 = TimestampOffset(offset2.timestamp, offset2.readTimestamp, Map("p3" -> 6L))
+      readOffset2.futureValue shouldBe Some(expectedOffset2)
+    }
+
+    "save TimestampOffset when same timestamp" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p2", 1L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p3", 5L)).futureValue
+      offsetStore.readOffset[TimestampOffset]()
+      offsetStore.getState().latestBySlice(slice("p1")) shouldBe offset1.timestamp
+      offsetStore.getState().latestBySlice(slice("p2")) shouldBe offset1.timestamp
+      offsetStore.getState().latestBySlice(slice("p3")) shouldBe offset1.timestamp
+      offsetStore.storedSeqNr("p1").futureValue shouldBe 3L
+      offsetStore.storedSeqNr("p2").futureValue shouldBe 1L
+      offsetStore.storedSeqNr("p3").futureValue shouldBe 5L
+
+      // not tick, same timestamp
+      val offset2 = TimestampOffset(clock.instant(), Map("p2" -> 2L, "p4" -> 9L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p2", 2L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p4", 9L)).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      // all should be included since same timestamp
+      // FIXME could be relevant if we use moreThanOneProjectionKey, otherwise remove
+//      val expectedOffset2 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 2L, "p3" -> 5L, "p4" -> 9L))
+//      readOffset2.futureValue shouldBe Some(withoutSeen(expectedOffset2))
+
+      // saving new with later timestamp
+      tick()
+      val offset3 = TimestampOffset(clock.instant(), Map("p1" -> 4L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset3, "p1", 4L)).futureValue
+      val readOffset3 = offsetStore.readOffset[TimestampOffset]()
+      // then it should only contain that entry
+      readOffset3.futureValue shouldBe Some(withoutSeen(offset3))
+      offsetStore.getState().latestBySlice(slice("p1")) shouldBe offset3.timestamp
+      offsetStore.storedSeqNr("p1").futureValue shouldBe 4L
+    }
+
+    "save batch of TimestampOffsets" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map("p5" -> 1L))
+      tick()
+      val offset3 = TimestampOffset(clock.instant(), Map("p6" -> 6L))
+      tick()
+      val offset4 = TimestampOffset(clock.instant(), Map("p1" -> 4L, "p3" -> 6L, "p4" -> 9L))
+      val offsetsBatch1 = Vector(
+        OffsetPidSeqNr(offset1, "p1", 3L),
+        OffsetPidSeqNr(offset1, "p2", 1L),
+        OffsetPidSeqNr(offset1, "p3", 5L),
+        OffsetPidSeqNr(offset2, "p5", 1L),
+        OffsetPidSeqNr(offset3, "p6", 6L),
+        OffsetPidSeqNr(offset4, "p1", 4L),
+        OffsetPidSeqNr(offset4, "p3", 6L),
+        OffsetPidSeqNr(offset4, "p4", 9L))
+
+      offsetStore.saveOffsets(offsetsBatch1).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      // FIXME could be relevant if we use moreThanOneProjectionKey, otherwise remove
+//      readOffset1.futureValue shouldBe Some(withoutSeen(offsetsBatch1.last.offset))
+      offsetStore.getState().byPid("p1").seqNr shouldBe 4L
+      offsetStore.getState().byPid("p2").seqNr shouldBe 1L
+      offsetStore.getState().byPid("p3").seqNr shouldBe 6L
+      offsetStore.getState().byPid("p4").seqNr shouldBe 9L
+      offsetStore.getState().byPid("p5").seqNr shouldBe 1L
+      offsetStore.getState().byPid("p6").seqNr shouldBe 6L
+
+      tick()
+      val offset5 = TimestampOffset(clock.instant(), Map("p1" -> 5L))
+      offsetStore.saveOffsets(Vector(OffsetPidSeqNr(offset5, "p1", 5L))).futureValue
+
+      tick()
+      // duplicate
+      val offset6 = TimestampOffset(clock.instant(), Map("p2" -> 1L))
+      offsetStore.saveOffsets(Vector(OffsetPidSeqNr(offset6, "p2", 1L))).futureValue
+
+      tick()
+      val offset7 = TimestampOffset(clock.instant(), Map("p1" -> 6L))
+      tick()
+      val offset8 = TimestampOffset(clock.instant(), Map("p1" -> 7L))
+      tick()
+      val offset9 = TimestampOffset(clock.instant(), Map("p1" -> 8L))
+      val offsetsBatch2 =
+        Vector(OffsetPidSeqNr(offset7, "p1", 6L), OffsetPidSeqNr(offset8, "p1", 7L), OffsetPidSeqNr(offset9, "p1", 8L))
+
+      offsetStore.saveOffsets(offsetsBatch2).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      readOffset2.futureValue shouldBe Some(withoutSeen(offsetsBatch2.last.offset))
+      offsetStore.getState().byPid("p1").seqNr shouldBe 8L
+      offsetStore.getState().byPid("p2").seqNr shouldBe 1L
+      offsetStore.getState().byPid("p3").seqNr shouldBe 6L
+      offsetStore.getState().byPid("p4").seqNr shouldBe 9L
+      offsetStore.getState().byPid("p5").seqNr shouldBe 1L
+      offsetStore.getState().byPid("p6").seqNr shouldBe 6L
+    }
+
+    "save batch of many TimestampOffsets" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      def test(pidPrefix: String, numberOfOffsets: Int): Unit = {
+        withClue(s"with $numberOfOffsets offsets: ") {
+          val offsetsBatch = (1 to numberOfOffsets).map { n =>
+            tick()
+            val offset = TimestampOffset(clock.instant(), Map.empty)
+            OffsetPidSeqNr(offset, s"$pidPrefix$n", n)
+          }
+          offsetStore.saveOffsets(offsetsBatch).futureValue
+          offsetStore.readOffset[TimestampOffset]().futureValue
+          (1 to numberOfOffsets).map { n =>
+            offsetStore.getState().byPid(s"$pidPrefix$n").seqNr shouldBe n
+          }
+        }
+      }
+
+      test("a", settings.offsetBatchSize)
+      test("a", settings.offsetBatchSize - 1)
+      test("a", settings.offsetBatchSize + 1)
+      test("a", settings.offsetBatchSize * 2)
+      test("a", settings.offsetBatchSize * 2 - 1)
+      test("a", settings.offsetBatchSize * 2 + 1)
+    }
+
+    "perf save batch of TimestampOffsets" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      val warmupIterations = 1 // increase this for serious testing
+      val iterations = 2000 // increase this for serious testing
+      val batchSize = 100
+
+      // warmup
+      (1 to warmupIterations).foreach { _ =>
+        val offsets = (1 to batchSize).map { n =>
+          val offset = TimestampOffset(Instant.now(), Map(s"p$n" -> 1L))
+          OffsetPidSeqNr(offset, s"p$n", 1L)
+        }
+        Await.result(offsetStore.saveOffsets(offsets), 5.seconds)
+      }
+
+      val totalStartTime = System.nanoTime()
+      var startTime = System.nanoTime()
+      var count = 0
+
+      (1 to iterations).foreach { i =>
+        val offsets = (1 to batchSize).map { n =>
+          val offset = TimestampOffset(Instant.now(), Map(s"p$n" -> 1L))
+          OffsetPidSeqNr(offset, s"p$n", 1L)
+        }
+        count += batchSize
+        Await.result(offsetStore.saveOffsets(offsets), 5.seconds)
+
+        if (i % 1000 == 0) {
+          val totalDurationMs = (System.nanoTime() - totalStartTime) / 1000 / 1000
+          val durationMs = (System.nanoTime() - startTime) / 1000 / 1000
+          println(
+            s"#${i * batchSize}: $count took $durationMs ms, RPS ${1000L * count / durationMs}, Total RPS ${1000L * i * batchSize / totalDurationMs}")
+          startTime = System.nanoTime()
+          count = 0
+        }
+      }
+    }
+
+    "not update when earlier seqNr" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      readOffset1.futureValue shouldBe Some(withoutSeen(offset1))
+
+      clock.setInstant(clock.instant().minusMillis(1))
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 2L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 2L)).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      readOffset2.futureValue shouldBe Some(withoutSeen(offset1)) // keeping offset1
+    }
+
+    "readOffset from given slices" in {
+      val projectionId0 = ProjectionId(UUID.randomUUID().toString, "0-1023")
+      val projectionId1 = ProjectionId(projectionId0.name, "0-511")
+      val projectionId2 = ProjectionId(projectionId0.name, "512-1023")
+
+      val p1 = "p1"
+      val slice1 = persistenceExt.sliceForPersistenceId(p1)
+      slice1 shouldBe 449
+
+      val p2 = "p2"
+      val slice2 = persistenceExt.sliceForPersistenceId(p2)
+      slice2 shouldBe 450
+
+      val p3 = "p10"
+      val slice3 = persistenceExt.sliceForPersistenceId(p3)
+      slice3 shouldBe 655
+
+      val p4 = "p11"
+      val slice4 = persistenceExt.sliceForPersistenceId(p4)
+      slice4 shouldBe 656
+
+      val offsetStore0 =
+        new DynamoDBOffsetStore(
+          projectionId0,
+          Some(new TestTimestampSourceProvider(0, persistenceExt.numberOfSlices - 1, clock)),
+          system,
+          settings,
+          client)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map(p1 -> 3L))
+      offsetStore0.saveOffset(OffsetPidSeqNr(offset1, p1, 3L)).futureValue
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map(p2 -> 4L))
+      offsetStore0.saveOffset(OffsetPidSeqNr(offset2, p2, 4L)).futureValue
+      tick()
+      val offset3 = TimestampOffset(clock.instant(), Map(p3 -> 7L))
+      offsetStore0.saveOffset(OffsetPidSeqNr(offset3, p3, 7L)).futureValue
+      tick()
+      val offset4 = TimestampOffset(clock.instant(), Map(p4 -> 5L))
+      offsetStore0.saveOffset(OffsetPidSeqNr(offset4, p4, 5L)).futureValue
+
+      val offsetStore1 =
+        new DynamoDBOffsetStore(
+          projectionId1,
+          Some(new TestTimestampSourceProvider(0, 511, clock)),
+          system,
+          settings,
+          client)
+      offsetStore1.readOffset().futureValue
+      offsetStore1.getState().byPid.keySet shouldBe Set(p1, p2)
+
+      val offsetStore2 =
+        new DynamoDBOffsetStore(
+          projectionId2,
+          Some(new TestTimestampSourceProvider(512, 1023, clock)),
+          system,
+          settings,
+          client)
+      offsetStore2.readOffset().futureValue
+      offsetStore2.getState().byPid.keySet shouldBe Set(p3, p4)
+    }
+
+    "filter duplicates" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p2", 1L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p3", 5L)).futureValue
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 4L, "p3" -> 6L, "p4" -> 9L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 4L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p3", 6L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p4", 9L)).futureValue
+      tick()
+      val offset3 = TimestampOffset(clock.instant(), Map("p5" -> 10L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset3, "p5", 10L)).futureValue
+
+      def env(pid: Pid, seqNr: SeqNr, timestamp: Instant): EventEnvelope[String] =
+        createEnvelope(pid, seqNr, timestamp, "evt")
+
+      offsetStore.validate(env("p5", 10, offset3.timestamp)).futureValue shouldBe Duplicate
+      offsetStore.validate(env("p1", 4, offset2.timestamp)).futureValue shouldBe Duplicate
+      offsetStore.validate(env("p3", 6, offset2.timestamp)).futureValue shouldBe Duplicate
+      offsetStore.validate(env("p4", 9, offset2.timestamp)).futureValue shouldBe Duplicate
+
+      offsetStore.validate(env("p1", 3, offset1.timestamp)).futureValue shouldBe Duplicate
+      offsetStore.validate(env("p2", 1, offset1.timestamp)).futureValue shouldBe Duplicate
+      offsetStore.validate(env("p3", 5, offset1.timestamp)).futureValue shouldBe Duplicate
+
+      offsetStore.validate(env("p1", 2, offset1.timestamp.minusMillis(1))).futureValue shouldBe Duplicate
+      offsetStore.validate(env("p5", 9, offset3.timestamp.minusMillis(1))).futureValue shouldBe Duplicate
+
+      offsetStore.validate(env("p5", 11, offset3.timestamp)).futureValue shouldNot be(Duplicate)
+      offsetStore.validate(env("p5", 12, offset3.timestamp.plusMillis(1))).futureValue shouldNot be(Duplicate)
+
+      offsetStore.validate(env("p6", 1, offset3.timestamp.plusMillis(2))).futureValue shouldNot be(Duplicate)
+      offsetStore.validate(env("p7", 1, offset3.timestamp.minusMillis(1))).futureValue shouldNot be(Duplicate)
+    }
+
+    "accept known sequence numbers and reject unknown" in {
+      val projectionId = genRandomProjectionId()
+      val eventTimestampQueryClock = TestClock.nowMicros()
+      val offsetStore = createOffsetStore(projectionId, eventTimestampQueryClock = eventTimestampQueryClock)
+
+      val startTime = TestClock.nowMicros().instant()
+      val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p2", 1L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p3", 5L)).futureValue
+
+      // seqNr 1 is always accepted
+      val env1 = createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")
+      offsetStore.validate(env1).futureValue shouldBe Accepted
+      offsetStore.validate(backtrackingEnvelope(env1)).futureValue shouldBe Accepted
+      // but not if already inflight, seqNr 1 was accepted
+      offsetStore.addInflight(env1)
+      val env1Later = createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")
+      offsetStore.validate(env1Later).futureValue shouldBe Duplicate
+      offsetStore.validate(backtrackingEnvelope(env1Later)).futureValue shouldBe Duplicate
+      // subsequent seqNr is accepted
+      val env2 = createEnvelope("p4", 2L, startTime.plusMillis(2), "e4-2")
+      offsetStore.validate(env2).futureValue shouldBe Accepted
+      offsetStore.validate(backtrackingEnvelope(env2)).futureValue shouldBe Accepted
+      offsetStore.addInflight(env2)
+      // but not when gap
+      val envP4SeqNr4 = createEnvelope("p4", 4L, startTime.plusMillis(3), "e4-4")
+      offsetStore.validate(envP4SeqNr4).futureValue shouldBe RejectedSeqNr
+      // hard reject when gap from backtracking
+      offsetStore.validate(backtrackingEnvelope(envP4SeqNr4)).futureValue shouldBe RejectedBacktrackingSeqNr
+      // reject filtered event when gap
+      offsetStore.validate(filteredEnvelope(envP4SeqNr4)).futureValue shouldBe RejectedSeqNr
+      // hard reject when filtered event with gap from backtracking
+      offsetStore
+        .validate(backtrackingEnvelope(filteredEnvelope(envP4SeqNr4)))
+        .futureValue shouldBe RejectedBacktrackingSeqNr
+      // and not if later already inflight, seqNr 2 was accepted
+      offsetStore.validate(createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")).futureValue shouldBe Duplicate
+
+      // +1 to known is accepted
+      val env3 = createEnvelope("p1", 4L, startTime.plusMillis(4), "e1-4")
+      offsetStore.validate(env3).futureValue shouldBe Accepted
+      // but not same
+      offsetStore.validate(createEnvelope("p3", 5L, startTime, "e3-5")).futureValue shouldBe Duplicate
+      // but not same, even if it's 1
+      offsetStore.validate(createEnvelope("p2", 1L, startTime, "e2-1")).futureValue shouldBe Duplicate
+      // and not less
+      offsetStore.validate(createEnvelope("p3", 4L, startTime, "e3-4")).futureValue shouldBe Duplicate
+      offsetStore.addInflight(env3)
+      // and then it's not accepted again
+      offsetStore.validate(env3).futureValue shouldBe Duplicate
+      offsetStore.validate(backtrackingEnvelope(env3)).futureValue shouldBe Duplicate
+      // and not when later seqNr is inflight
+      offsetStore.validate(env2).futureValue shouldBe Duplicate
+      offsetStore.validate(backtrackingEnvelope(env2)).futureValue shouldBe Duplicate
+
+      // +1 to known, and then also subsequent are accepted (needed for grouped)
+      val env4 = createEnvelope("p3", 6L, startTime.plusMillis(5), "e3-6")
+      offsetStore.validate(env4).futureValue shouldBe Accepted
+      offsetStore.addInflight(env4)
+      val env5 = createEnvelope("p3", 7L, startTime.plusMillis(6), "e3-7")
+      offsetStore.validate(env5).futureValue shouldBe Accepted
+      offsetStore.addInflight(env5)
+      val env6 = createEnvelope("p3", 8L, startTime.plusMillis(7), "e3-8")
+      offsetStore.validate(env6).futureValue shouldBe Accepted
+      offsetStore.addInflight(env6)
+
+      // reject unknown
+      val env7 = createEnvelope("p5", 7L, startTime.plusMillis(8), "e5-7")
+      offsetStore.validate(env7).futureValue shouldBe RejectedSeqNr
+      offsetStore.validate(backtrackingEnvelope(env7)).futureValue shouldBe RejectedBacktrackingSeqNr
+      // but ok when previous is old
+      eventTimestampQueryClock.setInstant(startTime.minusSeconds(3600))
+      val env8 = createEnvelope("p5", 7L, startTime.plusMillis(5), "e5-7")
+      offsetStore.validate(env8).futureValue shouldBe Accepted
+      eventTimestampQueryClock.setInstant(startTime)
+      offsetStore.addInflight(env8)
+      // and subsequent seqNr is accepted
+      val env9 = createEnvelope("p5", 8L, startTime.plusMillis(9), "e5-8")
+      offsetStore.validate(env9).futureValue shouldBe Accepted
+      offsetStore.addInflight(env9)
+
+      // reject unknown filtered
+      val env10 = filteredEnvelope(createEnvelope("p6", 7L, startTime.plusMillis(10), "e6-7"))
+      offsetStore.validate(env10).futureValue shouldBe RejectedSeqNr
+      // hard reject when unknown from backtracking
+      offsetStore.validate(backtrackingEnvelope(env10)).futureValue shouldBe RejectedBacktrackingSeqNr
+      // hard reject when unknown filtered event from backtracking
+      offsetStore
+        .validate(backtrackingEnvelope(filteredEnvelope(env10)))
+        .futureValue shouldBe RejectedBacktrackingSeqNr
+
+      // it's keeping the inflight that are not in the "stored" state
+      offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 8, "p4" -> 2L, "p5" -> 8)
+      // and they are removed from inflight once they have been stored
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(2), Map("p4" -> 2L)), "p4", 2L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(9), Map("p5" -> 8L)), "p5", 8L))
+        .futureValue
+      offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 8)
+    }
+
+    "update inflight on error and re-accept element" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      val startTime = TestClock.nowMicros().instant()
+
+      val envelope1 = createEnvelope("p1", 1L, startTime.plusMillis(1), "e1-1")
+      val envelope2 = createEnvelope("p1", 2L, startTime.plusMillis(2), "e1-2")
+      val envelope3 = createEnvelope("p1", 3L, startTime.plusMillis(2), "e1-2")
+
+      // seqNr 1 is always accepted
+      offsetStore.validate(envelope1).futureValue shouldBe Accepted
+      offsetStore.addInflight(envelope1)
+      offsetStore.getInflight() shouldBe Map("p1" -> 1L)
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(1), Map("p1" -> 1L)), "p1", 1L))
+        .futureValue
+      offsetStore.getInflight() shouldBe empty
+
+      // seqNr 2 is accepts since it follows seqNr 1 that is stored in state
+      offsetStore.validate(envelope2).futureValue shouldBe Accepted
+      // simulate envelope processing error by not adding envelope2 to inflight
+
+      // seqNr 3 is not accepted, still waiting for seqNr 2
+      offsetStore.validate(envelope3).futureValue shouldBe RejectedSeqNr
+
+      // offer seqNr 2 once again
+      offsetStore.validate(envelope2).futureValue shouldBe Accepted
+      offsetStore.addInflight(envelope2)
+      offsetStore.getInflight() shouldBe Map("p1" -> 2L)
+
+      // offer seqNr 3  once more
+      offsetStore.validate(envelope3).futureValue shouldBe Accepted
+      offsetStore.addInflight(envelope3)
+      offsetStore.getInflight() shouldBe Map("p1" -> 3L)
+
+      // and they are removed from inflight once they have been stored
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(2), Map("p1" -> 3L)), "p1", 3L))
+        .futureValue
+      offsetStore.getInflight() shouldBe empty
+    }
+
+    "mapIsAccepted" in {
+      val projectionId = genRandomProjectionId()
+      val startTime = TestClock.nowMicros().instant()
+      val offsetStore = createOffsetStore(projectionId)
+
+      val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p2", 1L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p3", 5L)).futureValue
+
+      // seqNr 1 is always accepted
+      val env1 = createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")
+      // subsequent seqNr is accepted
+      val env2 = createEnvelope("p4", 2L, startTime.plusMillis(2), "e4-2")
+      // but not when gap
+      val env3 = createEnvelope("p4", 4L, startTime.plusMillis(3), "e4-4")
+      // ok when previous is known
+      val env4 = createEnvelope("p1", 4L, startTime.plusMillis(5), "e1-4")
+      // but not when previous is unknown
+      val env5 = createEnvelope("p3", 7L, startTime.plusMillis(5), "e3-7")
+
+      offsetStore.validateAll(List(env1, env2, env3, env4, env5)).futureValue shouldBe List(
+        env1 -> Accepted,
+        env2 -> Accepted,
+        env3 -> RejectedSeqNr,
+        env4 -> Accepted,
+        env5 -> RejectedSeqNr)
+
+    }
+
+    "accept new revisions for durable state" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      val startTime = TestClock.nowMicros().instant()
+      val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p2", 1L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p3", 5L)).futureValue
+
+      // seqNr 1 is always accepted
+      val env1 = createUpdatedDurableState("p4", 1L, startTime.plusMillis(1), "s4-1")
+      offsetStore.validate(env1).futureValue shouldBe Accepted
+      // but not if already inflight, seqNr 1 was accepted
+      offsetStore.addInflight(env1)
+      offsetStore
+        .validate(createUpdatedDurableState("p4", 1L, startTime.plusMillis(1), "s4-1"))
+        .futureValue shouldBe Duplicate
+      // subsequent seqNr is accepted
+      val env2 = createUpdatedDurableState("p4", 2L, startTime.plusMillis(2), "s4-2")
+      offsetStore.validate(env2).futureValue shouldBe Accepted
+      offsetStore.addInflight(env2)
+      // and also ok with gap
+      offsetStore
+        .validate(createUpdatedDurableState("p4", 4L, startTime.plusMillis(3), "s4-4"))
+        .futureValue shouldBe Accepted
+      // and not if later already inflight, seqNr 2 was accepted
+      offsetStore
+        .validate(createUpdatedDurableState("p4", 1L, startTime.plusMillis(1), "s4-1"))
+        .futureValue shouldBe Duplicate
+
+      // greater than known is accepted
+      val env3 = createUpdatedDurableState("p1", 4L, startTime.plusMillis(4), "s1-4")
+      offsetStore.validate(env3).futureValue shouldBe Accepted
+      // but not same
+      offsetStore.validate(createUpdatedDurableState("p3", 5L, startTime, "s3-5")).futureValue shouldBe Duplicate
+      // but not same, even if it's 1
+      offsetStore.validate(createUpdatedDurableState("p2", 1L, startTime, "s2-1")).futureValue shouldBe Duplicate
+      // and not less
+      offsetStore.validate(createUpdatedDurableState("p3", 4L, startTime, "s3-4")).futureValue shouldBe Duplicate
+      offsetStore.addInflight(env3)
+
+      // greater than known, and then also subsequent are accepted (needed for grouped)
+      val env4 = createUpdatedDurableState("p3", 8L, startTime.plusMillis(5), "s3-6")
+      offsetStore.validate(env4).futureValue shouldBe Accepted
+      offsetStore.addInflight(env4)
+      val env5 = createUpdatedDurableState("p3", 9L, startTime.plusMillis(6), "s3-7")
+      offsetStore.validate(env5).futureValue shouldBe Accepted
+      offsetStore.addInflight(env5)
+      val env6 = createUpdatedDurableState("p3", 20L, startTime.plusMillis(7), "s3-8")
+      offsetStore.validate(env6).futureValue shouldBe Accepted
+      offsetStore.addInflight(env6)
+
+      // accept unknown
+      val env7 = createUpdatedDurableState("p5", 7L, startTime.plusMillis(8), "s5-7")
+      offsetStore.validate(env7).futureValue shouldBe Accepted
+      offsetStore.addInflight(env7)
+
+      // it's keeping the inflight that are not in the "stored" state
+      offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 20, "p4" -> 2L, "p5" -> 7)
+      // and they are removed from inflight once they have been stored
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(2), Map("p4" -> 2L)), "p4", 2L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(9), Map("p5" -> 8L)), "p5", 8L))
+        .futureValue
+      offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 20)
+    }
+
+    "evict old records" in {
+      val projectionId = genRandomProjectionId()
+      val evictSettings = settings.withTimeWindow(JDuration.ofSeconds(100)).withEvictInterval(JDuration.ofSeconds(10))
+      import evictSettings._
+      val offsetStore = createOffsetStore(projectionId, evictSettings)
+
+      val startTime = TestClock.nowMicros().instant()
+      log.debug("Start time [{}]", startTime)
+
+      // these pids have the same slice 645, otherwise it will keep one for each slice
+      val p1 = "p500"
+      val p2 = "p621"
+      val p3 = "p742"
+      val p4 = "p863"
+      val p5 = "p984"
+      val p6 = "p3080"
+      val p7 = "p4290"
+      val p8 = "p20180"
+
+      offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(startTime, Map(p1 -> 1L)), p1, 1L)).futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(1)), Map(p2 -> 1L)), p2, 1L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(2)), Map(p3 -> 1L)), p3, 1L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(evictInterval), Map(p4 -> 1L)), p4, 1L))
+        .futureValue
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(1)), Map(p4 -> 1L)),
+            p4,
+            1L))
+        .futureValue
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(2)), Map(p5 -> 1L)),
+            p5,
+            1L))
+        .futureValue
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(3)), Map(p6 -> 1L)),
+            p6,
+            3L))
+        .futureValue
+      offsetStore.getState().size shouldBe 6
+
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.minusSeconds(10)), Map(p7 -> 1L)), p7, 1L))
+        .futureValue
+      offsetStore.getState().size shouldBe 7 // nothing evicted yet
+
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).minusSeconds(3)), Map(p8 -> 1L)),
+            p8,
+            1L))
+        .futureValue
+      offsetStore.getState().size shouldBe 8 // still nothing evicted yet
+
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(1)), Map(p8 -> 2L)),
+            p8,
+            2L))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set(p5, p6, p7, p8)
+
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(20)), Map(p8 -> 3L)),
+            p8,
+            3L))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8)
+    }
+
+    "evict old records but keep latest for each slice" in {
+      val projectionId = genRandomProjectionId()
+      val evictSettings = settings.withTimeWindow(JDuration.ofSeconds(100)).withEvictInterval(JDuration.ofSeconds(10))
+      import evictSettings._
+      val offsetStore = createOffsetStore(projectionId, evictSettings)
+
+      val startTime = TestClock.nowMicros().instant()
+      log.debug("Start time [{}]", startTime)
+
+      val p1 = "p500" // slice 645
+      val p2 = "p92" // slice 905
+      val p3 = "p108" // slice 905
+      val p4 = "p863" // slice 645
+      val p5 = "p984" // slice 645
+      val p6 = "p3080" // slice 645
+      val p7 = "p4290" // slice 645
+      val p8 = "p20180" // slice 645
+
+      offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(startTime, Map(p1 -> 1L)), p1, 1L)).futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(1)), Map(p2 -> 1L)), p2, 1L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(2)), Map(p3 -> 1L)), p3, 1L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(evictInterval), Map(p4 -> 1L)), p4, 1L))
+        .futureValue
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(1)), Map(p4 -> 1L)),
+            p4,
+            1L))
+        .futureValue
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(2)), Map(p5 -> 1L)),
+            p5,
+            1L))
+        .futureValue
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(3)), Map(p6 -> 1L)),
+            p6,
+            1L))
+        .futureValue
+      offsetStore.getState().size shouldBe 6
+
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.minusSeconds(10)), Map(p7 -> 1L)), p7, 1L))
+        .futureValue
+      offsetStore.getState().size shouldBe 7 // nothing evicted yet
+
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).minusSeconds(3)), Map(p8 -> 1L)),
+            p8,
+            1L))
+        .futureValue
+      offsetStore.getState().size shouldBe 8 // still nothing evicted yet
+
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(1)), Map(p8 -> 2L)),
+            p8,
+            2L))
+        .futureValue
+      // also keeping p3 ("p108") for slice 905
+      offsetStore.getState().byPid.keySet shouldBe Set(p3, p5, p6, p7, p8)
+
+      offsetStore
+        .saveOffset(
+          OffsetPidSeqNr(
+            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(20)), Map(p8 -> 3L)),
+            p8,
+            3L))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set(p3, p7, p8)
+    }
+
+    "start from earliest slice" in {
+      // FIXME r2dbc has the condition " when projection key is changed"
+      val projectionId1 = ProjectionId(UUID.randomUUID().toString, "512-767")
+      val projectionId2 = ProjectionId(projectionId1.name, "768-1023")
+      val projectionId3 = ProjectionId(projectionId1.name, "512-1023")
+      val offsetStore1 = new DynamoDBOffsetStore(
+        projectionId1,
+        Some(new TestTimestampSourceProvider(512, 767, clock)),
+        system,
+        settings,
+        client)
+      val offsetStore2 = new DynamoDBOffsetStore(
+        projectionId2,
+        Some(new TestTimestampSourceProvider(768, 1023, clock)),
+        system,
+        settings,
+        client)
+
+      val p1 = "p500" // slice 645
+      val p2 = "p863" // slice 645
+      val p3 = "p11" // slice 656
+      val p4 = "p92" // slice 905
+
+      val time1 = TestClock.nowMicros().instant()
+      val time2 = time1.plusSeconds(1)
+      val time3 = time1.plusSeconds(2)
+      val time4 = time1.plusSeconds(3 * 60) // far ahead
+
+      offsetStore1.saveOffset(OffsetPidSeqNr(TimestampOffset(time1, Map(p1 -> 1L)), p1, 1L)).futureValue
+      offsetStore1.saveOffset(OffsetPidSeqNr(TimestampOffset(time2, Map(p2 -> 1L)), p2, 1L)).futureValue
+      offsetStore1.saveOffset(OffsetPidSeqNr(TimestampOffset(time3, Map(p3 -> 1L)), p3, 1L)).futureValue
+      offsetStore2
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(time4, Map(p4 -> 1L)), p4, 1L))
+        .futureValue
+
+      // after downscaling
+      val offsetStore3 = new DynamoDBOffsetStore(
+        projectionId3,
+        Some(new TestTimestampSourceProvider(512, 1023, clock)),
+        system,
+        settings,
+        client)
+
+      val offset =
+        TimestampOffset.toTimestampOffset(offsetStore3.readOffset().futureValue.get) // this will load from database
+      offsetStore3.getState().size shouldBe 4
+
+      offset.timestamp shouldBe time2
+      // FIXME seen not reconstructed
+//      offset.seen shouldBe Map(p2 -> 1L)
+
+      // getOffset is used by management api, and that should not be adjusted
+      TimestampOffset.toTimestampOffset(offsetStore3.getOffset().futureValue.get).timestamp shouldBe time4
+    }
+
+    // FIXME more tests, see r2dbc
+    //    "set offset" in {
+    //    "clear offset" in {
+    //    "read and save paused" in {
+
+  }
+}

--- a/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -969,11 +969,10 @@ class DynamoDBTimestampOffsetStoreSpec
       offsetStore3.getState().offsetBySlice.size shouldBe 3
 
       offset.timestamp shouldBe time2
-      // FIXME seen not reconstructed
-//      offset.seen shouldBe Map(p2 -> 1L)
+      offset.seen shouldBe Map(p2 -> 1L)
 
       // getOffset is used by management api, and that should not be adjusted
-      // FIXME TimestampOffset.toTimestampOffset(offsetStore3.getOffset().futureValue.get).timestamp shouldBe time4
+      TimestampOffset.toTimestampOffset(offsetStore3.getOffset().futureValue.get).timestamp shouldBe time4
     }
 
     // FIXME more tests, see r2dbc

--- a/projection/src/test/scala/akka/projection/dynamodb/TestClock.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/TestClock.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalUnit
+
+import akka.annotation.InternalApi
+
+object TestClock {
+  def nowMillis(): TestClock = new TestClock(ChronoUnit.MILLIS)
+  def nowMicros(): TestClock = new TestClock(ChronoUnit.MICROS)
+}
+
+/**
+ * Clock for testing purpose, which is truncated to a resolution (milliseconds or microseconds).
+ *
+ * The reason for truncating to the resolution is that Postgres timestamps has the resolution of microseconds but some
+ * OS/JDK (Linux/JDK17) has Instant resolution of nanoseconds.
+ */
+@InternalApi private[projection] class TestClock(resolution: TemporalUnit) extends Clock {
+
+  @volatile private var _instant = Instant.now().truncatedTo(resolution)
+
+  override def getZone: ZoneId = ZoneOffset.UTC
+
+  override def withZone(zone: ZoneId): Clock =
+    throw new UnsupportedOperationException("withZone not supported")
+
+  override def instant(): Instant =
+    _instant
+
+  def setInstant(newInstant: Instant): Unit =
+    _instant = newInstant.truncatedTo(resolution)
+
+  /**
+   * Increase the clock with this duration (truncated to the resolution)
+   */
+  def tick(duration: Duration): Instant = {
+    val newInstant = _instant.plus(duration).truncatedTo(resolution)
+    _instant = newInstant
+    newInstant
+  }
+
+}

--- a/projection/src/test/scala/akka/projection/dynamodb/TestConfig.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/TestConfig.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+object TestConfig {
+  lazy val config: Config = {
+    val defaultConfig = ConfigFactory.load()
+
+    ConfigFactory
+      .parseString("""
+      akka.loglevel = DEBUG
+      akka.persistence.journal.plugin = "akka.persistence.dynamodb.journal"
+      # FIXME akka.persistence.snapshot-store.plugin = "akka.persistence.dynamodb.snapshot"
+      akka.persistence.dynamodb {
+        query {
+          refresh-interval = 1s
+        }
+      }
+      akka.actor.testkit.typed.default-timeout = 10s
+      """)
+      .withFallback(defaultConfig)
+  }
+
+}

--- a/projection/src/test/scala/akka/projection/dynamodb/TestData.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/TestData.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb
+
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.annotation.tailrec
+
+import akka.actor.typed.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.typed.PersistenceId
+import akka.projection.ProjectionId
+
+object TestData {
+  private val start = 0L // could be something more unique, like currentTimeMillis
+  private val pidCounter = new AtomicLong(start)
+  private val entityTypeCounter = new AtomicLong(start)
+}
+
+trait TestData {
+  import TestData.entityTypeCounter
+  import TestData.pidCounter
+
+  def typedSystem: ActorSystem[_]
+
+  private lazy val persistenceExt = Persistence(typedSystem)
+
+  def nextPid(): String = s"p-${pidCounter.incrementAndGet()}"
+
+  def nextEntityType(): String = s"TestEntity-${entityTypeCounter.incrementAndGet()}"
+
+  def nextPersistenceId(entityType: String): PersistenceId =
+    PersistenceId.of(entityType, s"${pidCounter.incrementAndGet()}")
+
+  @tailrec final def randomPersistenceIdForSlice(entityType: String, slice: Int): PersistenceId = {
+    val p = PersistenceId.of(entityType, UUID.randomUUID().toString)
+    if (persistenceExt.sliceForPersistenceId(p.id) == slice) p
+    else randomPersistenceIdForSlice(entityType, slice)
+  }
+
+  def genRandomProjectionId(): ProjectionId = ProjectionId(UUID.randomUUID().toString, "00")
+
+}

--- a/projection/src/test/scala/akka/projection/dynamodb/TestDbLifecycle.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/TestDbLifecycle.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb
+
+import java.time.Instant
+import java.util.concurrent.CompletionException
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.control.NonFatal
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.dynamodb.ClientProvider
+import akka.persistence.dynamodb.DynamoDBSettings
+import akka.persistence.dynamodb.internal.InstantFactory
+import akka.persistence.dynamodb.internal.JournalAttributes
+import akka.persistence.typed.PersistenceId
+import akka.serialization.SerializationExtension
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Suite
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
+import software.amazon.awssdk.services.dynamodb.model.KeyType
+import software.amazon.awssdk.services.dynamodb.model.Projection
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
+
+trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
+
+  def typedSystem: ActorSystem[_]
+
+  def testConfigPath: String = "akka.projection.dynamodb"
+
+  lazy val settings: DynamoDBProjectionSettings =
+    DynamoDBProjectionSettings(typedSystem.settings.config.getConfig(testConfigPath))
+
+  lazy val dynamoDBSettings: DynamoDBSettings =
+    DynamoDBSettings(
+      typedSystem.settings.config
+        .getConfig(settings.useClient.replace(".client", "")))
+
+  lazy val persistenceExt: Persistence = Persistence(typedSystem)
+
+  lazy val client: DynamoDbAsyncClient = ClientProvider(typedSystem).clientFor(settings.useClient)
+
+  private lazy val log = LoggerFactory.getLogger(getClass)
+
+  override protected def beforeAll(): Unit = {
+    try {
+      Await.result(createJournalTable(), 10.seconds)
+      Await.result(createTimestampOffsetStoreTable(), 10.seconds)
+    } catch {
+      case NonFatal(ex) => throw new RuntimeException(s"Test db creation failed", ex)
+    }
+
+    super.beforeAll()
+  }
+
+  private def createJournalTable(): Future[Done] = {
+    import akka.persistence.dynamodb.internal.JournalAttributes._
+    implicit val ec: ExecutionContext = typedSystem.executionContext
+
+    val existingTable =
+      client.describeTable(DescribeTableRequest.builder().tableName(dynamoDBSettings.journalTable).build()).asScala
+
+    def create(): Future[Done] = {
+      val sliceIndex = GlobalSecondaryIndex
+        .builder()
+        .indexName(dynamoDBSettings.journalBySliceGsi)
+        .keySchema(
+          KeySchemaElement.builder().attributeName(EntityTypeSlice).keyType(KeyType.HASH).build(),
+          KeySchemaElement.builder().attributeName(Timestamp).keyType(KeyType.RANGE).build())
+        .projection(
+          Projection.builder().projectionType(ProjectionType.ALL).build()
+        ) // FIXME we could skip a few attributes
+        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(10L).writeCapacityUnits(10L).build())
+        .build()
+
+      val req = CreateTableRequest
+        .builder()
+        .tableName(dynamoDBSettings.journalTable)
+        .keySchema(
+          KeySchemaElement.builder().attributeName(Pid).keyType(KeyType.HASH).build(),
+          KeySchemaElement.builder().attributeName(SeqNr).keyType(KeyType.RANGE).build())
+        .attributeDefinitions(
+          AttributeDefinition.builder().attributeName(Pid).attributeType(ScalarAttributeType.S).build(),
+          AttributeDefinition.builder().attributeName(SeqNr).attributeType(ScalarAttributeType.N).build(),
+          AttributeDefinition.builder().attributeName(EntityTypeSlice).attributeType(ScalarAttributeType.S).build(),
+          AttributeDefinition.builder().attributeName(Timestamp).attributeType(ScalarAttributeType.N).build())
+        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build())
+        .globalSecondaryIndexes(sliceIndex)
+        .build()
+
+      client.createTable(req).asScala.map(_ => Done)(typedSystem.executionContext)
+    }
+
+    def delete(): Future[Done] = {
+      val req = DeleteTableRequest.builder().tableName(dynamoDBSettings.journalTable).build()
+      client.deleteTable(req).asScala.map(_ => Done)(typedSystem.executionContext)
+    }
+
+    existingTable.transformWith {
+      case Success(_)                            => delete().flatMap(_ => create())
+      case Failure(_: ResourceNotFoundException) => create()
+      case Failure(exception: CompletionException) =>
+        exception.getCause match {
+          case _: ResourceNotFoundException => create()
+          case failure                      => Future.failed[Done](failure)
+        }
+      case Failure(exc) =>
+        Future.failed[Done](exc)
+    }
+  }
+
+  private def createTimestampOffsetStoreTable(): Future[Done] = {
+    import akka.projection.dynamodb.internal.OffsetStoreDao.OffsetStoreAttributes._
+    implicit val ec: ExecutionContext = typedSystem.executionContext
+
+    val existingTable =
+      client.describeTable(DescribeTableRequest.builder().tableName(settings.timestampOffsetTable).build()).asScala
+
+    def create(): Future[Done] = {
+      val req = CreateTableRequest
+        .builder()
+        .tableName(settings.timestampOffsetTable)
+        .keySchema(
+          KeySchemaElement.builder().attributeName(NameSlice).keyType(KeyType.HASH).build(),
+          KeySchemaElement.builder().attributeName(Pid).keyType(KeyType.RANGE).build())
+        .attributeDefinitions(
+          AttributeDefinition.builder().attributeName(NameSlice).attributeType(ScalarAttributeType.S).build(),
+          AttributeDefinition.builder().attributeName(Pid).attributeType(ScalarAttributeType.S).build())
+        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build())
+        .build()
+
+      client.createTable(req).asScala.map(_ => Done)(typedSystem.executionContext)
+    }
+
+    def delete(): Future[Done] = {
+      val req = DeleteTableRequest.builder().tableName(settings.timestampOffsetTable).build()
+      client.deleteTable(req).asScala.map(_ => Done)(typedSystem.executionContext)
+    }
+
+    existingTable.transformWith {
+      case Success(_)                            => delete().flatMap(_ => create())
+      case Failure(_: ResourceNotFoundException) => create()
+      case Failure(exception: CompletionException) =>
+        exception.getCause match {
+          case _: ResourceNotFoundException => create()
+          case failure                      => Future.failed[Done](failure)
+        }
+      case Failure(exc) =>
+        Future.failed[Done](exc)
+    }
+  }
+
+}


### PR DESCRIPTION
I have been thinking about how we would design the DynamoDB data model for the offset store.

We need to keep track of latest seqNr per pid for deduplication and ordering validations. We also need latest timestamp per slice, which is used for the offset when starting the projection.

In r2dbc we append one row for each pid/seqNr. We only need the latest seqNr for each pid, so we delete old records that fall outside the time window. It was changed from updates to inserts because then we could use the timestamp in the primary key as index for the deletes. https://github.com/akka/akka-persistence-r2dbc/commit/8bd80c795d35d35e1406d2a4b2a25c227cc7c906#diff-c371488121fb75c46ede0860fb1ca592119bac624e43d4479e0e744b06dc1d88

This is a different approach than r2dbc:
  - one item type for latest timestamp per slice
    - (projection_name, slice) as partition key
    - no sort key
    - updates timestamp
    - this will not be deleted
  - another item type for deduplication purposes
    - (projection_name, slice) as partition key
    - persistence_id as sort key
    - load for specific persistence_id on demand
    - updates seq_nr and TTL
    - deleted with TTL, and that can be far in the future
    
