### PR TITLE
feat: use offset by slice

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/TimestampOffsetBySlice.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/TimestampOffsetBySlice.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.dynamodb.internal
+
+import akka.annotation.InternalApi
+import akka.persistence.query.Offset
+import akka.persistence.query.TimestampOffset
+
+// FIXME maybe move to akka-persistence-query if it should be shared with r2dbc
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object TimestampOffsetBySlice {
+  val empty: TimestampOffsetBySlice = new TimestampOffsetBySlice(Map.empty)
+
+  def apply(offsets: Map[Int, TimestampOffset]): TimestampOffsetBySlice =
+    new TimestampOffsetBySlice(offsets)
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class TimestampOffsetBySlice(val offsets: Map[Int, TimestampOffset]) extends Offset


### PR DESCRIPTION
* the offset store keeps track of TimestampOffset per slice
* return a composite TimestampOffsetBySlice from readOffset
* eventsBySlice can then start each query from the more exact offset per slice
* means much less loading and deduplication than when starting all queries from earliest offset of all slices

