### PR TITLE
refactor: projection atLeastOnce

### DIFF
--- a/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -168,7 +168,7 @@ private[projection] object DynamoDBProjectionImpl {
     }
   }
 
-  private[projection] def adaptedHandlerForAtLeastOnceAsync[Offset, Envelope](
+  private[projection] def adaptedHandlerForAtLeastOnce[Offset, Envelope](
       sourceProvider: SourceProvider[Offset, Envelope],
       handlerFactory: () => Handler[Envelope],
       offsetStore: DynamoDBOffsetStore)(implicit

--- a/projection/src/main/scala/akka/projection/dynamodb/javadsl/DynamoDBProjection.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/javadsl/DynamoDBProjection.scala
@@ -26,9 +26,6 @@ object DynamoDBProjection {
   /**
    * Create a [[akka.projection.Projection]] with at-least-once processing semantics.
    *
-   * Compared to [[DynamoDBProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in DynamoDB, but
-   * is integrating with something else.
-   *
    * It stores the offset in a DynamoDB table after the `handler` has processed the envelope. This means that if the
    * projection is restarted from previously stored offset then some elements may be processed more than once.
    *
@@ -36,7 +33,7 @@ object DynamoDBProjection {
    * can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned `AtLeastOnceProjection`. The default
    * settings for the window is defined in configuration section `akka.projection.at-least-once`.
    */
-  def atLeastOnceAsync[Offset, Envelope](
+  def atLeastOnce[Offset, Envelope](
       projectionId: ProjectionId,
       settings: Optional[DynamoDBProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
@@ -44,7 +41,7 @@ object DynamoDBProjection {
       system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
 
     scaladsl.DynamoDBProjection
-      .atLeastOnceAsync[Offset, Envelope](
+      .atLeastOnce[Offset, Envelope](
         projectionId,
         settings.toScala,
         JavaToScalaBySliceSourceProviderAdapter(sourceProvider),

--- a/projection/src/main/scala/akka/projection/dynamodb/scaladsl/DynamoDBProjection.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/scaladsl/DynamoDBProjection.scala
@@ -4,9 +4,6 @@
 
 package akka.projection.dynamodb.scaladsl
 
-import scala.concurrent.duration.FiniteDuration
-
-import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
 import akka.persistence.dynamodb.ClientProvider
@@ -20,16 +17,12 @@ import akka.projection.internal.SingleHandlerStrategy
 import akka.projection.scaladsl.AtLeastOnceProjection
 import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
-import akka.stream.scaladsl.FlowWithContext
 
 @ApiMayChange
 object DynamoDBProjection {
 
   /**
    * Create a [[akka.projection.Projection]] with at-least-once processing semantics.
-   *
-   * Compared to [[DynamoDBProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in DynamoDB, but
-   * is integrating with something else.
    *
    * It stores the offset in a DynamoDB table after the `handler` has processed the envelope. This means that if the
    * projection is restarted from previously stored offset then some elements may be processed more than once.
@@ -38,7 +31,7 @@ object DynamoDBProjection {
    * can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned `AtLeastOnceProjection`. The default
    * settings for the window is defined in configuration section `akka.projection.at-least-once`.
    */
-  def atLeastOnceAsync[Offset, Envelope](
+  def atLeastOnce[Offset, Envelope](
       projectionId: ProjectionId,
       settings: Option[DynamoDBProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
@@ -55,7 +48,7 @@ object DynamoDBProjection {
         client)
 
     val adaptedHandler =
-      DynamoDBProjectionImpl.adaptedHandlerForAtLeastOnceAsync(sourceProvider, handler, offsetStore)(
+      DynamoDBProjectionImpl.adaptedHandlerForAtLeastOnce(sourceProvider, handler, offsetStore)(
         system.executionContext,
         system)
 

--- a/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -374,7 +374,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
 
       val projection =
-        DynamoDBProjection.atLeastOnceAsync(
+        DynamoDBProjection.atLeastOnce(
           projectionId,
           Some(settings),
           sourceProvider,
@@ -398,7 +398,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
 
       val projection =
-        DynamoDBProjection.atLeastOnceAsync(
+        DynamoDBProjection.atLeastOnce(
           projectionId,
           Some(settings),
           sourceProvider,
@@ -423,8 +423,9 @@ class DynamoDBTimestampOffsetProjectionSpec
       implicit val offsetStore: DynamoDBOffsetStore =
         new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
 
-      val projectionRef = spawn(ProjectionBehavior(DynamoDBProjection
-        .atLeastOnceAsync(projectionId, Some(settings), sourceProvider, handler = () => new ConcatHandler(repository))))
+      val projectionRef = spawn(
+        ProjectionBehavior(DynamoDBProjection
+          .atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => new ConcatHandler(repository))))
       val input = sourceProvider.input.futureValue
 
       val envelopes1 = createEnvelopesUnknownSequenceNumbers(startTime, pid1, pid2)
@@ -467,7 +468,7 @@ class DynamoDBTimestampOffsetProjectionSpec
 
       val projectionFailing =
         DynamoDBProjection
-          .atLeastOnceAsync(projectionId, Some(settings), sourceProvider, handler = () => bogusEventHandler)
+          .atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => bogusEventHandler)
           .withSaveOffset(afterEnvelopes = 5, afterDuration = 2.seconds)
           .withRecoveryStrategy(HandlerRecoveryStrategy.retryAndSkip(2, 10.millis))
 
@@ -496,7 +497,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
 
       val projection =
-        DynamoDBProjection.atLeastOnceAsync(
+        DynamoDBProjection.atLeastOnce(
           projectionId,
           Some(settings),
           sourceProvider,
@@ -531,7 +532,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       }
 
       val projection =
-        DynamoDBProjection.atLeastOnceAsync(projectionId, Some(settings), sourceProvider, handler = () => handler())
+        DynamoDBProjection.atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => handler())
 
       projectionTestKit.run(projection) {
         result.toString shouldBe "e1|e2|e3|e4|e5|e6|"
@@ -571,7 +572,7 @@ class DynamoDBTimestampOffsetProjectionSpec
 
       val projectionFailing =
         DynamoDBProjection
-          .atLeastOnceAsync(projectionId, Some(settings), sourceProvider, handler = () => handler())
+          .atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => handler())
           .withSaveOffset(afterEnvelopes = 5, afterDuration = 2.seconds)
           .withRecoveryStrategy(HandlerRecoveryStrategy.retryAndSkip(2, 10.millis))
 
@@ -610,7 +611,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       }
 
       val projection =
-        DynamoDBProjection.atLeastOnceAsync(projectionId, Some(settings), sourceProvider, handler = () => handler())
+        DynamoDBProjection.atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => handler())
 
       projectionTestKit.run(projection) {
         result1.toString shouldBe "e1-1|e1-2|e1-3|e1-4|"
@@ -648,7 +649,7 @@ class DynamoDBTimestampOffsetProjectionSpec
 
       val projectionRef = spawn(
         ProjectionBehavior(
-          DynamoDBProjection.atLeastOnceAsync(projectionId, Some(settings), sourceProvider, handler = () => handler())))
+          DynamoDBProjection.atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => handler())))
       val input = sourceProvider.input.futureValue
 
       val envelopes1 = createEnvelopesUnknownSequenceNumbers(startTime, pid1, pid2)
@@ -690,7 +691,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
 
       val projection =
-        DynamoDBProjection.atLeastOnceAsync(
+        DynamoDBProjection.atLeastOnce(
           projectionId,
           Some(settings),
           sourceProvider,


### PR DESCRIPTION
Refs #22 

Suggestion to just have `atLeastOnce`, without the distinction between `atLeastOnce` (same database) and `atLeastOnceAsync` (general handler).