### PR TITLE
feat: exactly-once projection

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/TimestampOffsetBySlice.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/TimestampOffsetBySlice.scala
@@ -24,4 +24,6 @@ import akka.persistence.query.TimestampOffset
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] class TimestampOffsetBySlice(val offsets: Map[Int, TimestampOffset]) extends Offset
+@InternalApi private[akka] class TimestampOffsetBySlice(val offsets: Map[Int, TimestampOffset]) extends Offset {
+  override def toString = s"TimestampOffsetBySlice($offsets)"
+}

--- a/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBHandlerAdapter.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBHandlerAdapter.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb.internal
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.projection.dynamodb.javadsl
+import akka.projection.dynamodb.scaladsl
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+
+/**
+ * INTERNAL API: Adapter from javadsl.DynamoDBTransactHandler to scaladsl.DynamoDBTransactHandler
+ */
+@InternalApi private[projection] class DynamoDBTransactHandlerAdapter[Envelope](
+    delegate: javadsl.DynamoDBTransactHandler[Envelope])
+    extends scaladsl.DynamoDBTransactHandler[Envelope] {
+
+  override def process(envelope: Envelope): Future[Iterable[TransactWriteItem]] =
+    delegate.process(envelope).asScala.map(_.asScala)(ExecutionContexts.parasitic)
+
+  override def start(): Future[Done] =
+    delegate.start().asScala
+
+  override def stop(): Future[Done] =
+    delegate.stop().asScala
+}

--- a/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -315,97 +315,19 @@ private[projection] class DynamoDBOffsetStore(
   def saveOffset(offset: OffsetPidSeqNr): Future[Done] =
     saveOffsets(Vector(offset))
 
-  def saveOffsets(offsets: IndexedSeq[OffsetPidSeqNr]): Future[Done] = {
-    if (offsets.isEmpty)
-      FutureDone
-    else if (offsets.head.offset.isInstanceOf[TimestampOffset]) {
-      val records = offsets.map {
-        case OffsetPidSeqNr(t: TimestampOffset, Some((pid, seqNr))) =>
-          val slice = persistenceExt.sliceForPersistenceId(pid)
-          Record(slice, pid, seqNr, t.timestamp)
-        case OffsetPidSeqNr(_: TimestampOffset, None) =>
-          throw new IllegalArgumentException("Required EventEnvelope or DurableStateChange for TimestampOffset.")
-        case _ =>
-          throw new IllegalArgumentException(
-            "Mix of TimestampOffset and other offset type in same transaction is not supported")
-      }
-      saveTimestampOffsets(records)
-    } else {
-      throw new IllegalStateException("TimestampOffset is required. Primitive offsets not supported.")
-    }
-  }
-
-  private def saveTimestampOffsets(records: IndexedSeq[Record]): Future[Done] = {
-    load(records.map(_.pid)).flatMap { _ =>
-      val oldState = state.get()
-      val filteredRecords = {
-        if (records.size <= 1)
-          records.filterNot(oldState.isDuplicate)
-        else {
-          // use last record for each pid
-          records
-            .groupBy(_.pid)
-            .valuesIterator
-            .collect {
-              case recordsByPid if !oldState.isDuplicate(recordsByPid.last) => recordsByPid.last
-            }
-            .toVector
-        }
-      }
-      if (filteredRecords.isEmpty) {
-        FutureDone
-      } else {
-        val newState = oldState.add(filteredRecords)
-
-        // accumulate some more than the timeWindow before evicting, and at least 10% increase of size
-        // for testing keepNumberOfEntries = 0 is used
-        val evictThresholdReached =
-          if (settings.keepNumberOfEntries == 0) true else newState.size > (newState.sizeAfterEvict * 1.1).toInt
-        val evictedNewState =
-          if (newState.size > settings.keepNumberOfEntries && evictThresholdReached && newState.window
-              .compareTo(evictWindow) > 0) {
-            // FIXME maybe this should take the slice into account
-            val evictUntil = newState.latestTimestamp.minus(settings.timeWindow)
-            val s = newState.evict(evictUntil, settings.keepNumberOfEntries)
-            logger.debug(
-              "{} Evicted [{}] records until [{}], keeping [{}] records. Latest [{}].",
-              logPrefix,
-              newState.size - s.size,
-              evictUntil,
-              s.size,
-              newState.latestTimestamp)
-            s
-          } else
-            newState
-
-        // FIXME we probably don't have to store the latest offset per slice all the time, but can
-        // accumulate some changes and flush on size/time.
-        val changedOffsetBySlice = evictedNewState.offsetBySlice.filter { case (slice, offset) =>
-          offset != oldState.offsetBySlice.getOrElse(slice, TimestampOffset.Zero)
-        }
-
-        dao.storeSequenceNumbers(filteredRecords).flatMap { _ =>
-          val storeOffsetsResult =
-            if (changedOffsetBySlice.isEmpty) FutureDone else dao.storeTimestampOffsets(changedOffsetBySlice)
-          storeOffsetsResult.flatMap { _ =>
-            if (state.compareAndSet(oldState, evictedNewState)) {
-              cleanupInflight(evictedNewState)
-              FutureDone
-            } else
-              saveTimestampOffsets(records) // CAS retry, concurrent update
-          }
-        }
-
-      }
-    }
-  }
+  def saveOffsets(offsets: IndexedSeq[OffsetPidSeqNr]): Future[Done] =
+    storeOffsets(offsets, dao.storeSequenceNumbers, canBeConcurrent = true)
 
   def transactSaveOffset(writeItems: Iterable[TransactWriteItem], offset: OffsetPidSeqNr): Future[Done] =
     transactSaveOffsets(writeItems, Vector(offset))
 
-  def transactSaveOffsets(
-      writeItems: Iterable[TransactWriteItem],
-      offsets: IndexedSeq[OffsetPidSeqNr]): Future[Done] = {
+  def transactSaveOffsets(writeItems: Iterable[TransactWriteItem], offsets: IndexedSeq[OffsetPidSeqNr]): Future[Done] =
+    storeOffsets(offsets, dao.transactStoreSequenceNumbers(writeItems), canBeConcurrent = false)
+
+  private def storeOffsets(
+      offsets: IndexedSeq[OffsetPidSeqNr],
+      storeSequenceNumbers: IndexedSeq[Record] => Future[Done],
+      canBeConcurrent: Boolean): Future[Done] = {
     if (offsets.isEmpty)
       FutureDone
     else if (offsets.head.offset.isInstanceOf[TimestampOffset]) {
@@ -419,15 +341,16 @@ private[projection] class DynamoDBOffsetStore(
           throw new IllegalArgumentException(
             "Mix of TimestampOffset and other offset type in same transaction is not supported")
       }
-      transactSaveTimestampOffsets(writeItems, records)
+      storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent)
     } else {
       throw new IllegalStateException("TimestampOffset is required. Primitive offsets not supported.")
     }
   }
 
-  private def transactSaveTimestampOffsets(
-      writeItems: Iterable[TransactWriteItem],
-      records: IndexedSeq[Record]): Future[Done] = {
+  private def storeTimestampOffsets(
+      records: IndexedSeq[Record],
+      storeSequenceNumbers: IndexedSeq[Record] => Future[Done],
+      canBeConcurrent: Boolean): Future[Done] = {
     load(records.map(_.pid)).flatMap { _ =>
       val oldState = state.get()
       val filteredRecords = {
@@ -476,16 +399,17 @@ private[projection] class DynamoDBOffsetStore(
           offset != oldState.offsetBySlice.getOrElse(slice, TimestampOffset.Zero)
         }
 
-        dao.transactStoreSequenceNumbers(writeItems, filteredRecords).flatMap { _ =>
+        storeSequenceNumbers(filteredRecords).flatMap { _ =>
           val storeOffsetsResult =
             if (changedOffsetBySlice.isEmpty) FutureDone else dao.storeTimestampOffsets(changedOffsetBySlice)
           storeOffsetsResult.flatMap { _ =>
             if (state.compareAndSet(oldState, evictedNewState)) {
               cleanupInflight(evictedNewState)
               FutureDone
-            } else
-              throw new IllegalStateException(
-                "Unexpected concurrent modification of state in transactional save offsets.")
+            } else { // concurrent update
+              if (canBeConcurrent) storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent) // CAS retry
+              else throw new IllegalStateException("Unexpected concurrent modification of state in save offsets.")
+            }
           }
         }
       }

--- a/projection/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
@@ -232,7 +232,7 @@ import software.amazon.awssdk.services.dynamodb.model.WriteRequest
     }
   }
 
-  def transactStoreSequenceNumbers(writeItems: Iterable[TransactWriteItem], records: Seq[Record]): Future[Done] = {
+  def transactStoreSequenceNumbers(writeItems: Iterable[TransactWriteItem])(records: Seq[Record]): Future[Done] = {
     val writeSequenceNumbers = records.map { record =>
       TransactWriteItem.builder
         .put(

--- a/projection/src/main/scala/akka/projection/dynamodb/javadsl/DynamoDBTransactHandler.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/javadsl/DynamoDBTransactHandler.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb.javadsl
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.function.{ Function => JFunction }
+import java.util.{ Collection => JCollection }
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
+import akka.projection.javadsl.HandlerLifecycle
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+
+/**
+ * Implement this interface for the Envelope handler for DynamoDB transactional projections.
+ *
+ * It can be stateful, with variables and mutable data structures. It is invoked by the `Projection` machinery one
+ * envelope at a time and visibility guarantees between the invocations are handled automatically, i.e. no volatile or
+ * other concurrency primitives are needed for managing the state.
+ *
+ * Supported error handling strategies for when processing an `Envelope` fails can be defined in configuration or using
+ * the `withRecoveryStrategy` method of a `Projection` implementation.
+ */
+@ApiMayChange
+trait DynamoDBTransactHandler[Envelope] extends HandlerLifecycle {
+
+  /**
+   * The `process` method is invoked for each `Envelope`, and should return DynamoDB `TransactWriteItem`s to atomically
+   * write along with the projection offset.
+   *
+   * One envelope is processed at a time. It will not be invoked with the next envelope until the returned
+   * CompletionStage has completed and the given items written in a transaction.
+   */
+  def process(envelope: Envelope): CompletionStage[JCollection[TransactWriteItem]]
+
+  def start(): CompletionStage[Done] =
+    CompletableFuture.completedFuture(Done)
+
+  def stop(): CompletionStage[Done] =
+    CompletableFuture.completedFuture(Done)
+}
+
+@ApiMayChange
+object DynamoDBTransactHandler {
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private class DynamoDBTransactHandlerFunction[Envelope](
+      handler: JFunction[Envelope, CompletionStage[JCollection[TransactWriteItem]]])
+      extends DynamoDBTransactHandler[Envelope] {
+
+    override def process(envelope: Envelope): CompletionStage[JCollection[TransactWriteItem]] = handler.apply(envelope)
+  }
+
+  /** DynamoDBTransactHandler that can be defined with a simple function */
+  def fromFunction[Envelope](handler: JFunction[Envelope, CompletionStage[JCollection[TransactWriteItem]]])
+      : DynamoDBTransactHandler[Envelope] =
+    new DynamoDBTransactHandlerFunction(handler)
+}

--- a/projection/src/main/scala/akka/projection/dynamodb/scaladsl/DynamoDBTransactHandler.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/scaladsl/DynamoDBTransactHandler.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.dynamodb.scaladsl
+
+import scala.concurrent.Future
+
+import akka.annotation.ApiMayChange
+import akka.projection.scaladsl.HandlerLifecycle
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+
+/**
+ * Implement this interface for the Envelope handler for DynamoDB transactional projections.
+ *
+ * It can be stateful, with variables and mutable data structures. It is invoked by the `Projection` machinery one
+ * envelope at a time and visibility guarantees between the invocations are handled automatically, i.e. no volatile or
+ * other concurrency primitives are needed for managing the state.
+ *
+ * Supported error handling strategies for when processing an `Envelope` fails can be defined in configuration or using
+ * the `withRecoveryStrategy` method of a `Projection` implementation.
+ */
+@ApiMayChange
+trait DynamoDBTransactHandler[Envelope] extends HandlerLifecycle {
+
+  /**
+   * The `process` method is invoked for each `Envelope`, and should return DynamoDB `TransactWriteItem`s to atomically
+   * write along with the projection offset.
+   *
+   * One envelope is processed at a time. It will not be invoked with the next envelope until the returned Future has
+   * completed and the given items written in a transaction.
+   */
+  def process(envelope: Envelope): Future[Iterable[TransactWriteItem]]
+}
+
+@ApiMayChange
+object DynamoDBTransactHandler {
+
+  private class DynamoDBTransactHandlerFunction[Envelope](handler: Envelope => Future[Iterable[TransactWriteItem]])
+      extends DynamoDBTransactHandler[Envelope] {
+
+    override def process(envelope: Envelope): Future[Iterable[TransactWriteItem]] = handler(envelope)
+  }
+
+  /** DynamoDBTransactHandler that can be defined with a simple function */
+  def apply[Envelope](handler: Envelope => Future[Iterable[TransactWriteItem]]): DynamoDBTransactHandler[Envelope] =
+    new DynamoDBTransactHandlerFunction(handler)
+}


### PR DESCRIPTION
Refs #21 

Current WIP for adding exactly-once projections. Mostly in place. It's not possible to do reads and writes in the same transaction, so API is returning a future of `TransactWriteItem`s, so a read can still be done first with a client (and could use transact get items).

- [x] Doesn't yet do anything about the CAS retry.
- [x] A couple of tests still marked pending, because there are `TimestampOffsetBySlice` class cast exceptions.


