### PR TITLE
test: Run tests with real DynamoDB

### DIFF
--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -13,7 +13,7 @@
     </logger>
 
     <logger name="akka.persistence.dynamodb" level="DEBUG" />
-    <logger name="software.amazon.awssdk" level="DEBUG" />
+    <logger name="software.amazon.awssdk.request" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="CapturingAppender"/>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -13,7 +13,7 @@
     </logger>
 
     <logger name="akka.persistence.dynamodb" level="DEBUG" />
-
+    <logger name="software.amazon.awssdk" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="CapturingAppender"/>

--- a/core/src/test/scala/akka/persistence/dynamodb/TestData.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/TestData.scala
@@ -16,12 +16,10 @@ import akka.persistence.typed.PersistenceId
 object TestData {
   private val start = 0L // could be something more unique, like currentTimeMillis
   private val pidCounter = new AtomicLong(start)
-  private val entityTypeCounter = new AtomicLong(start)
 }
 
 trait TestData {
   import TestData.pidCounter
-  import TestData.entityTypeCounter
 
   def typedSystem: ActorSystem[_]
 
@@ -29,7 +27,7 @@ trait TestData {
 
   def nextPid(): String = s"p-${pidCounter.incrementAndGet()}"
 
-  def nextEntityType(): String = s"TestEntity-${entityTypeCounter.incrementAndGet()}"
+  def nextEntityType(): String = s"TestEntity-${UUID.randomUUID()}"
 
   def nextPersistenceId(entityType: String): PersistenceId =
     PersistenceId.of(entityType, s"${pidCounter.incrementAndGet()}")

--- a/projection/src/test/resources/logback-test.xml
+++ b/projection/src/test/resources/logback-test.xml
@@ -15,6 +15,7 @@
     <logger name="akka.projection" level="DEBUG" />
     <logger name="akka.projection.dynamodb" level="TRACE" />
     <logger name="akka.persistence.dynamodb" level="DEBUG" />
+    <logger name="software.amazon.awssdk" level="DEBUG" />
 
 
     <root level="INFO">

--- a/projection/src/test/resources/logback-test.xml
+++ b/projection/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
     <logger name="akka.projection" level="DEBUG" />
     <logger name="akka.projection.dynamodb" level="TRACE" />
     <logger name="akka.persistence.dynamodb" level="DEBUG" />
-    <logger name="software.amazon.awssdk" level="DEBUG" />
+    <logger name="software.amazon.awssdk.request" level="DEBUG" />
 
 
     <root level="INFO">

--- a/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -262,7 +262,8 @@ class DynamoDBTimestampOffsetProjectionSpec
   private val repository = new TestRepository()
 
   override protected def beforeAll(): Unit = {
-    Await.result(TestTable.create(client, system), 10.seconds)
+    if (localDynamoDB)
+      Await.result(TestTable.create(client, system), 10.seconds)
     super.beforeAll()
   }
 

--- a/projection/src/test/scala/akka/projection/dynamodb/TestData.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/TestData.scala
@@ -17,11 +17,9 @@ import akka.projection.ProjectionId
 object TestData {
   private val start = 0L // could be something more unique, like currentTimeMillis
   private val pidCounter = new AtomicLong(start)
-  private val entityTypeCounter = new AtomicLong(start)
 }
 
 trait TestData {
-  import TestData.entityTypeCounter
   import TestData.pidCounter
 
   def typedSystem: ActorSystem[_]
@@ -30,7 +28,7 @@ trait TestData {
 
   def nextPid(): String = s"p-${pidCounter.incrementAndGet()}"
 
-  def nextEntityType(): String = s"TestEntity-${entityTypeCounter.incrementAndGet()}"
+  def nextEntityType(): String = s"TestEntity-${UUID.randomUUID()}"
 
   def nextPersistenceId(entityType: String): PersistenceId =
     PersistenceId.of(entityType, s"${pidCounter.incrementAndGet()}")

--- a/scripts/create-tables.sh
+++ b/scripts/create-tables.sh
@@ -13,22 +13,22 @@ aws dynamodb create-table \
     --provisioned-throughput \
         ReadCapacityUnits=5,WriteCapacityUnits=5 \
     --global-secondary-indexes \
-            "[
-                {
-                    \"IndexName\": \"event_journal_slice_idx\",
-                    \"KeySchema\": [
-                        {\"AttributeName\":\"entity_type_slice\",\"KeyType\":\"HASH\"},
-                        {\"AttributeName\":\"ts\",\"KeyType\":\"RANGE\"}
-                    ],
-                    \"Projection\": {
-                        \"ProjectionType\":\"ALL\"
-                    },
-                    \"ProvisionedThroughput\": {
-                        \"ReadCapacityUnits\": 5,
-                        \"WriteCapacityUnits\": 5
-                    }
-                }
-            ]"
+      '[
+         {
+           "IndexName": "event_journal_slice_idx",
+           "KeySchema": [
+             {"AttributeName": "entity_type_slice", "KeyType": "HASH"},
+             {"AttributeName": "ts", "KeyType": "RANGE"}
+           ],
+           "Projection": {
+             "ProjectionType": "ALL"
+           },
+           "ProvisionedThroughput": {
+             "ReadCapacityUnits": 5,
+             "WriteCapacityUnits": 5
+           }
+        }
+      ]'
 
 
 aws dynamodb create-table \

--- a/scripts/create-tables.sh
+++ b/scripts/create-tables.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+aws dynamodb create-table \
+    --table-name event_journal \
+    --attribute-definitions \
+        AttributeName=pid,AttributeType=S \
+        AttributeName=seq_nr,AttributeType=N \
+        AttributeName=entity_type_slice,AttributeType=S \
+        AttributeName=ts,AttributeType=N \
+    --key-schema \
+        AttributeName=pid,KeyType=HASH \
+        AttributeName=seq_nr,KeyType=RANGE \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5 \
+    --global-secondary-indexes \
+            "[
+                {
+                    \"IndexName\": \"event_journal_slice_idx\",
+                    \"KeySchema\": [
+                        {\"AttributeName\":\"entity_type_slice\",\"KeyType\":\"HASH\"},
+                        {\"AttributeName\":\"ts\",\"KeyType\":\"RANGE\"}
+                    ],
+                    \"Projection\": {
+                        \"ProjectionType\":\"ALL\"
+                    },
+                    \"ProvisionedThroughput\": {
+                        \"ReadCapacityUnits\": 5,
+                        \"WriteCapacityUnits\": 5
+                    }
+                }
+            ]"
+
+
+aws dynamodb create-table \
+    --table-name snapshot \
+    --attribute-definitions \
+        AttributeName=pid,AttributeType=S \
+    --key-schema \
+        AttributeName=pid,KeyType=HASH \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5
+
+aws dynamodb create-table \
+    --table-name timestamp_offset \
+    --attribute-definitions \
+        AttributeName=name_slice,AttributeType=S \
+        AttributeName=pid,AttributeType=S \
+    --key-schema \
+        AttributeName=name_slice,KeyType=HASH \
+        AttributeName=pid,KeyType=RANGE \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5
+
+aws dynamodb create-table \
+    --table-name projection_spec \
+    --attribute-definitions \
+        AttributeName=id,AttributeType=S \
+    --key-schema \
+        AttributeName=id,KeyType=HASH \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5

--- a/scripts/delete-tables.sh
+++ b/scripts/delete-tables.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+aws dynamodb delete-table --table-name event_journal
+aws dynamodb delete-table --table-name snapshot
+aws dynamodb delete-table --table-name timestamp_offset
+
+aws dynamodb delete-table --table-name projection_spec


### PR DESCRIPTION
Tried running tests from ec2 instance. Many tests are successful but also some failures or at least flakiness. Next would probably be to understand the throttling. Maybe some tests should be rewritten to consume less capacity, if we want to run them with real DynamoDB, or maybe that would just be occasional tests with enough provisioned capacity?

* create/delete tables didn't work well, disabled that for non-local
* therefore also unique nextEntityType with uuid instead of counter
