### PR TITLE
docs: extend to cover current functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val docs = project
   .in(file("docs"))
   .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .disablePlugins(MimaPlugin, CiReleasePlugin)
-  .dependsOn(core)
+  .dependsOn(core % "compile;test->test")
   .settings(common)
   .settings(dontPublish)
   .settings(
@@ -117,9 +117,7 @@ lazy val docs = project
     Preprocess / siteSubdirName := s"api/akka-persistence-dynamodb/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Paradox / siteSubdirName := s"docs/akka-persistence-dynamodb/${projectInfoVersion.value}",
-    paradoxGroups := Map(
-      "Language" -> Seq("Java", "Scala"),
-      "Dialect" -> Seq("Postgres", "Yugabyte", "H2", "SQLServer")),
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     Compile / paradoxProperties ++= Map(
       "project.url" -> "https://doc.akka.io/docs/akka-persistence-dynamodb/current/",
       "canonical.base_url" -> "https://doc.akka.io/docs/akka-persistence-dynamodb/current",

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/PubSub.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/PubSub.scala
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory
           .find(_.contains(slice))
           .getOrElse(throw new IllegalArgumentException(s"Slice [$slice] not found in " +
           s"slice ranges [${sliceRanges.mkString(", ")}]")))
-    URLEncoder.encode(s"r2dbc-$entityType-${range.min}-${range.max}", StandardCharsets.UTF_8.name())
+    URLEncoder.encode(s"dynamodb-$entityType-${range.min}-${range.max}", StandardCharsets.UTF_8.name())
   }
 
   def publish(pr: PersistentRepr, timestamp: Instant): Unit = {

--- a/core/src/main/scala/akka/persistence/dynamodb/util/javadsl/CreateTables.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/util/javadsl/CreateTables.scala
@@ -22,4 +22,10 @@ object CreateTables {
       deleteIfExists: Boolean): CompletionStage[Done] =
     scaladsl.CreateTables.createJournalTable(system, settings, client, deleteIfExists).asJava
 
+  def createSnapshotsTable(
+      system: ActorSystem[_],
+      settings: DynamoDBSettings,
+      client: DynamoDbAsyncClient,
+      deleteIfExists: Boolean): CompletionStage[Done] =
+    scaladsl.CreateTables.createSnapshotsTable(system, settings, client, deleteIfExists).asJava
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   dynamodb-local:
     command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"

--- a/docs/src/main/paradox/config.md
+++ b/docs/src/main/paradox/config.md
@@ -32,4 +32,25 @@ See @ref:[Query plugin configuration](query.md#configuration).
 
 ## Multiple plugins
 
-TODO see r2dbc docs
+To enable the DynamoDB plugins to be used by default, add the following lines to your `application.conf`:
+
+@@snip [default plugins](/docs/src/test/scala/docs/scaladsl/MultiPluginDocExample.scala) { #default-config }
+
+Note that all plugins have a shared root config section `akka.persistence.dynamodb`, which also contains the
+@ref:[DynamoDB client configuration](#dynamodb-client-configuration).
+
+You can use additional plugins with different configuration. For example, a second configuration could be defined:
+
+@@snip [second config](/docs/src/test/scala/docs/scaladsl/MultiPluginDocExample.scala) { #second-config }
+
+To use the additional plugin you would @scala[define]@java[override] the plugin id:
+
+Java
+: @@snip [with plugins](/docs/src/test/java/docs/javadsl/MultiPluginDocExample.java) { #with-plugins }
+
+Scala
+: @@snip [with plugins](/docs/src/test/scala/docs/scaladsl/MultiPluginDocExample.scala) { #with-plugins }
+
+For queries and projection `SourceProvider` you would use `"second-dynamodb.query"` instead of the default
+@scala[`DynamoDBReadJournal.Identifier`]@java[`DynamoDBReadJournal.Identifier()`]
+(`"akka.persistence.dynamodb.query"`).

--- a/docs/src/main/paradox/getting-started.md
+++ b/docs/src/main/paradox/getting-started.md
@@ -2,7 +2,8 @@
 
 ## Dependencies
 
-The Akka dependencies are available from Akka's library repository. To access them there, you need to configure the URL for this repository.
+The Akka dependencies are available from Akka's library repository. To access them there, you need to configure the URL
+for this repository.
 
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
@@ -39,3 +40,37 @@ More information about each individual plugin in:
 * @ref:[snapshot store](snapshots.md)
 * @ref:[queries](query.md)
 
+## Local testing with docker
+
+[DynamoDB local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) can be run in
+Docker. Here's an example docker compose file:
+
+@@snip [docker-compose.yml](/docker/docker-compose.yml)
+
+Start with:
+
+```
+docker compose -f docker/docker-compose.yml up
+```
+
+### Client local mode
+
+The DynamoDB client @ref:[can be configured](config.md#dynamodb-client-configuration) with a local mode, for testing
+with DynamoDB local:
+
+@@snip [local mode](/docs/src/test/scala/docs/scaladsl/CreateTablesDocExample.scala) { #local-mode }
+
+### Creating tables locally
+
+A @apidoc[akka.persistence.dynamodb.util.*.CreateTables$] utility is provided for creating tables locally:
+
+Java
+: @@snip [create tables](/docs/src/test/java/docs/javadsl/CreateTablesDocExample.java) { #create-tables }
+
+Scala
+: @@snip [create tables](/docs/src/test/scala/docs/scaladsl/CreateTablesDocExample.scala) { #create-tables }
+
+See the table definitions in the individual plugins for more information on the tables that are required:
+
+* @ref:[journal tables](journal.md#tables)
+* @ref:[snapshot tables](snapshots.md#tables)

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -3,9 +3,39 @@
 The journal plugin enables storing and loading events for
 @extref:[event sourced persistent actors](akka:typed/persistence.html).
 
-## Schema
+## Tables
 
-TODO not schema, but maybe table provisioning and such
+The journal plugin requires an event journal table to be created in DynamoDB. The default table name is `event_journal`
+and this can be configured (see the @ref:[reference configuration](#reference-configuration) for all settings). The
+table should be created with the following attributes and key schema:
+
+| Attribute name | Attribute type | Key type |
+| -------------- | -------------- | -------- |
+| pid            | S (String)     | HASH     |
+| seq_nr         | N (Number)     | RANGE    |
+
+Read capacity units should be based on expected entity recoveries. Write capacity units should be based on expected
+rates for persisting events.
+
+If @ref:[queries](query.md) or @ref:[projections](projection.md) are being used, then a global secondary index needs to
+be added to the event journal table, to index events by slice. The default name for the secondary index is
+`event_journal_slice_idx`. The following attribute definitions should be added to the event journal table, with key
+schema for the event journal slice index:
+
+| Attribute name    | Attribute type | Key type |
+| ----------------- | -------------- | -------- |
+| entity_type_slice | S (String)     | HASH     |
+| ts                | N (Number)     | RANGE    |
+
+Write capacity units for the index should be aligned with the event journal. Read capacity units should be based on
+expected queries.
+
+An example `aws` CLI command for creating the event journal table and slice index:
+
+@@snip [aws create event journal table](/scripts/create-tables.sh) { #create-event-journal-table }
+
+For creating tables with DynamoDB local for testing, see the
+@ref:[CreateTables utility](getting-started.md#creating-tables-locally).
 
 ## Configuration
 
@@ -30,6 +60,4 @@ The events are serialized with @extref:[Akka Serialization](akka:serialization.h
 is stored in the `event_payload` column together with information about what serializer that was used in the
 `event_ser_id` and `event_ser_manifest` columns.
 
-## Deletes
-
-TODO
+<!-- TODO: ## Deletes -->

--- a/docs/src/main/paradox/query.md
+++ b/docs/src/main/paradox/query.md
@@ -1,7 +1,116 @@
 # Query Plugin
 
-TODO
+## Event sourced queries
+
+@apidoc[DynamoDBReadJournal] implements the following @extref:[Persistence Queries](akka:persistence-query.html):
+
+* `eventsBySlices`, `currentEventsBySlices`
+
+Accessing the `DynamoDBReadJournal`:
+
+Java
+:  @@snip [access read journal](/docs/src/test/java/docs/javadsl/QueryDocExample.java) { #access-read-journal }
+
+Scala
+:  @@snip [access read journal](/docs/src/test/scala/docs/scaladsl/QueryDocExample.scala) { #access-read-journal }
+
+### eventsBySlices
+
+The `eventsBySlices` and `currentEventsBySlices` queries are useful for retrieving all events for a given entity type.
+`eventsBySlices` should be used via Akka Projection.
+
+@@@ note
+This has historically been done with `eventsByTag` but the DynamoDB plugin is instead providing `eventsBySlices`
+as an improved solution.
+
+The usage of `eventsByTag` for Projections has the drawback that the number of tags must be decided up-front and can't
+easily be changed afterwards. Starting with too many tags means a lot of overhead, since many projection instances
+would be running on each node in a small Akka Cluster, with each projection instance polling the database periodically.
+Starting with too few tags means that it can't be scaled later to more Akka nodes.
+
+With `eventsBySlices` more Projection instances can be added when needed and still reuse the offsets for the previous
+slice distributions.
+@@@
+
+A slice is deterministically defined based on the persistence id. The purpose is to evenly distribute all
+persistence ids over the slices. The `eventsBySlices` query is for a range of the slices. For example if
+using 1024 slices and running 4 Projection instances the slice ranges would be 0-255, 256-511, 512-767, 768-1023.
+Changing to 8 slice ranges means that the ranges would be 0-127, 128-255, 256-383, ..., 768-895, 896-1023.
+
+Example of `currentEventsBySlices`:
+
+Java
+:  @@snip [create](/docs/src/test/java/docs/javadsl/QueryDocExample.java) { #current-events-by-slices }
+
+Scala
+:  @@snip [create](/docs/src/test/scala/docs/scaladsl/QueryDocExample.scala) { #current-events-by-slices }
+
+`eventsBySlices` should be used via @ref:[DynamoDBProjection](projection.md), which will automatically handle some
+challenges around ordering and missed events.
+
+When using `DynamoDBProjection` the events will be delivered in sequence number order without duplicates.
+
+The consumer can keep track of its current position in the event stream by storing the `offset` and restarting the
+query from a given `offset` after a crash/restart.
+
+The offset is a `TimestampOffset`, based on when the event was stored. This means that a "later" event may be visible
+first. When retrieving events after the previously seen timestamp we may miss some events and emit an event with a
+later sequence number for a persistence id, without emitting all preceding events. `eventsBySlices` will perform
+additional backtracking queries to catch missed events. Events from backtracking will typically be duplicates of
+previously emitted events. It's the responsibility of the consumer to filter duplicates and make sure that events are
+processed in exact sequence number order for each persistence id, and such de-duplication is provided by the DynamoDB
+Projection.
+
+Events emitted by backtracking don't contain the event payload (`EventBySliceEnvelope.event` is None) and the consumer
+can load the full `EventBySliceEnvelope` with @apidoc[DynamoDBReadJournal.loadEnvelope](DynamoDBReadJournal) {
+scala="#loadEnvelope[Event](persistenceId:String,sequenceNr:Long):scala.concurrent.Future[akka.persistence.query.typed.EventEnvelope[Event]]"
+java="#loadEnvelope[Event](persistenceId:String,sequenceNr:Long):java.util.concurrent.CompletionStage[akka.persistence.query.typed.EventEnvelope[Event]]"
+}.
+
+Events will be emitted in timestamp order with the caveat of duplicate events as described above. Events with the same
+timestamp are ordered by sequence number.
+
+`currentEventsBySlices` doesn't perform backtracking queries, will not emit duplicates, and the event payload is always
+fully loaded.
+
+### Publish events for lower latency of eventsBySlices
+
+The `eventsBySlices` query polls the database periodically to find new events. By default, this interval is a few
+seconds, see `akka.persistence.dynamodb.query.refresh-interval` in the @ref:[Configuration](#configuration). This
+interval can be reduced for lower latency, with the drawback of querying the database more frequently.
+
+To reduce the latency there is a feature that will publish the events within the Akka Cluster. Running `eventsBySlices`
+will subscribe to the events and emit them directly without waiting for the next query poll. The trade-off is that more
+CPU and network resources are used. The events must still be retrieved from the database, but at a lower polling
+frequency, because delivery of published messages are not guaranteed.
+
+This feature is enabled by default and it will measure the throughput and automatically disable/enable if
+the exponentially weighted moving average of measured throughput exceeds the configured threshold.
+
+```
+akka.persistence.dynamodb.journal.publish-events-dynamic.throughput-threshold = 400
+```
+
+Disable publishing of events with configuration:
+
+```
+akka.persistence.dynamodb.journal.publish-events = off
+```
+
+If you use many queries or Projection instances you should consider adjusting the
+`akka.persistence.dynamodb.journal.publish-events-number-of-topics` configuration, see
+@ref:[Configuration](#configuration).
 
 ## Configuration
 
-TODO
+Query configuration is under `akka.persistence.dynamodb.query`.
+
+The query plugin shares the @ref:[DynamoDB client configuration](config.md#dynamodb-client-configuration) with other
+plugins.
+
+### Reference configuration
+
+The following can be overridden in your `application.conf` for query specific settings:
+
+@@snip [reference.conf](/core/src/main/resources/reference.conf) {#query-settings}
+

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -3,9 +3,25 @@
 The snapshot plugin enables storing and loading snapshots for
 @extref:[event sourced persistent actors](akka:typed/persistence.html).
 
-## Schema
+## Tables
 
-TODO not schema, but maybe table provisioning and such
+The snapshot plugin requires a snapshot table to be created in DynamoDB. The default table name is `snapshot` and this
+can be configured (see the @ref:[reference configuration](#reference-configuration) for all settings). The table should
+be created with the following attributes and key schema:
+
+| Attribute name | Attribute type | Key type |
+| -------------- | -------------- | -------- |
+| pid            | S (String)     | HASH     |
+
+Read capacity units should be based on expected entity recoveries. Write capacity units should be based on expected
+rates for persisting snapshots.
+
+An example `aws` CLI command for creating the snapshot table:
+
+@@snip [aws create snapshot table](/scripts/create-tables.sh) { #create-snapshot-table }
+
+For creating tables with DynamoDB local for testing, see the
+@ref:[CreateTables utility](getting-started.md#creating-tables-locally).
 
 ## Configuration
 

--- a/docs/src/test/java/docs/javadsl/CreateTablesDocExample.java
+++ b/docs/src/test/java/docs/javadsl/CreateTablesDocExample.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import java.util.concurrent.TimeUnit;
+
+import akka.actor.typed.ActorSystem;
+
+// #create-tables
+import akka.persistence.dynamodb.DynamoDBSettings;
+import akka.persistence.dynamodb.util.ClientProvider;
+import akka.persistence.dynamodb.util.javadsl.CreateTables;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+// #create-tables
+
+public class CreateTablesDocExample {
+
+  public static void createTables(ActorSystem<?> system) throws Exception {
+    // #create-tables
+    String dynamoDBConfigPath = "akka.persistence.dynamodb";
+    String dynamoDBClientConfigPath = dynamoDBConfigPath + ".client";
+
+    DynamoDBSettings settings =
+        DynamoDBSettings.create(system.settings().config().getConfig(dynamoDBConfigPath));
+
+    DynamoDbAsyncClient client = ClientProvider.get(system).clientFor(dynamoDBClientConfigPath);
+
+    // create journal table, synchronously
+    CreateTables.createJournalTable(system, settings, client, /*deleteIfExists:*/ true)
+        .toCompletableFuture()
+        .get(10, TimeUnit.SECONDS);
+
+    // create snapshot table, synchronously
+    CreateTables.createSnapshotsTable(system, settings, client, /*deleteIfExists:*/ true)
+        .toCompletableFuture()
+        .get(10, TimeUnit.SECONDS);
+    // #create-tables
+  }
+
+}

--- a/docs/src/test/java/docs/javadsl/MultiPluginDocExample.java
+++ b/docs/src/test/java/docs/javadsl/MultiPluginDocExample.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.persistence.typed.PersistenceId;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.EventHandler;
+import akka.persistence.typed.javadsl.EventSourcedBehavior;
+
+public class MultiPluginDocExample {
+
+  public interface Command {}
+
+  public interface Event {}
+
+  public static class State {}
+
+  // #with-plugins
+  public class MyEntity extends EventSourcedBehavior<Command, Event, State> {
+    // #with-plugins
+    public MyEntity(PersistenceId persistenceId) {
+      super(persistenceId);
+    }
+
+    @Override
+    public State emptyState() {
+      return new State();
+    }
+
+    @Override
+    public CommandHandler<Command, Event, State> commandHandler() {
+      return newCommandHandlerBuilder().build();
+    }
+
+    @Override
+    public EventHandler<State, Event> eventHandler() {
+      return newEventHandlerBuilder().build();
+    }
+
+    // #with-plugins
+    @Override
+    public String journalPluginId() {
+      return "second-dynamodb.journal";
+    }
+
+    @Override
+    public String snapshotPluginId() {
+      return "second-dynamodb.snapshot";
+    }
+  }
+  // #with-plugins
+
+}

--- a/docs/src/test/java/docs/javadsl/QueryDocExample.java
+++ b/docs/src/test/java/docs/javadsl/QueryDocExample.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import java.util.List;
+
+import akka.actor.typed.ActorSystem;
+
+// #access-read-journal
+import akka.persistence.dynamodb.query.javadsl.DynamoDBReadJournal;
+import akka.persistence.query.PersistenceQuery;
+
+// #access-read-journal
+
+// #current-events-by-slices
+import akka.NotUsed;
+import akka.japi.Pair;
+import akka.persistence.query.NoOffset;
+import akka.persistence.query.typed.EventEnvelope;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+
+// #current-events-by-slices
+
+public class QueryDocExample {
+
+  interface MyEvent {}
+
+  public static DynamoDBReadJournal accessReadJournal(ActorSystem<?> system) {
+    // #access-read-journal
+    DynamoDBReadJournal eventQueries =
+        PersistenceQuery.get(system)
+            .getReadJournalFor(DynamoDBReadJournal.class, DynamoDBReadJournal.Identifier());
+    // #access-read-journal
+
+    return eventQueries;
+  }
+
+  void currentEventsBySlicesExampleCompileOnly(ActorSystem<?> system) {
+    DynamoDBReadJournal eventQueries = accessReadJournal(system);
+
+    // #current-events-by-slices
+    // Split the slices into 4 ranges
+    int numberOfSliceRanges = 4;
+    List<Pair<Integer, Integer>> sliceRanges = eventQueries.sliceRanges(numberOfSliceRanges);
+
+    // Example of using the first slice range
+    int minSlice = sliceRanges.get(0).first();
+    int maxSlice = sliceRanges.get(0).second();
+    String entityType = "MyEntity";
+    Source<EventEnvelope<MyEvent>, NotUsed> source =
+        eventQueries.currentEventsBySlices(entityType, minSlice, maxSlice, NoOffset.getInstance());
+    source
+        .map(
+            envelope ->
+                "event from persistenceId "
+                    + envelope.persistenceId()
+                    + " with seqNr "
+                    + envelope.sequenceNr()
+                    + ": "
+                    + envelope.event())
+        .runWith(Sink.foreach(System.out::println), system);
+    // #current-events-by-slices
+  }
+}

--- a/docs/src/test/scala/docs/scaladsl/CreateTablesDocExample.scala
+++ b/docs/src/test/scala/docs/scaladsl/CreateTablesDocExample.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Futures
+import org.scalatest.wordspec.AnyWordSpecLike
+
+//#create-tables
+import akka.persistence.dynamodb.DynamoDBSettings
+import akka.persistence.dynamodb.util.ClientProvider
+import akka.persistence.dynamodb.util.scaladsl.CreateTables
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+//#create-tables
+
+object CreateTablesDocExample {
+  val config: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    //#local-mode
+    akka.persistence.dynamodb {
+      client.local.enabled = true
+    }
+    //#local-mode
+    """))
+}
+
+class CreateTablesDocExample
+    extends ScalaTestWithActorTestKit(CreateTablesDocExample.config)
+    with AnyWordSpecLike
+    with Futures {
+
+  "Getting started docs" should {
+
+    "have example of creating tables locally (Scala)" in {
+      //#create-tables
+      val dynamoDBConfigPath = "akka.persistence.dynamodb"
+      val dynamoDBClientConfigPath = dynamoDBConfigPath + ".client"
+
+      val settings: DynamoDBSettings = DynamoDBSettings(system.settings.config.getConfig(dynamoDBConfigPath))
+      val client: DynamoDbAsyncClient = ClientProvider(system).clientFor(dynamoDBClientConfigPath)
+
+      // create journal table, synchronously
+      Await.result(CreateTables.createJournalTable(system, settings, client, deleteIfExists = true), 10.seconds)
+
+      // create snapshot table, synchronously
+      Await.result(CreateTables.createSnapshotsTable(system, settings, client, deleteIfExists = true), 10.seconds)
+      //#create-tables
+    }
+
+    "have example of creating tables locally (Java)" in {
+      docs.javadsl.CreateTablesDocExample.createTables(system)
+    }
+
+  }
+}

--- a/docs/src/test/scala/docs/scaladsl/MultiPluginDocExample.scala
+++ b/docs/src/test/scala/docs/scaladsl/MultiPluginDocExample.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.persistence.dynamodb.TestConfig
+import akka.persistence.dynamodb.TestData
+import akka.persistence.dynamodb.TestDbLifecycle
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.scaladsl.Effect
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object MultiPluginDocExample {
+  val config: Config = ConfigFactory
+    .parseString("""
+    //#default-config
+    akka.persistence.journal.plugin = "akka.persistence.dynamodb.journal"
+    akka.persistence.snapshot-store.plugin = "akka.persistence.dynamodb.snapshot"
+    //#default-config
+
+    //#second-config
+    second-dynamodb = ${akka.persistence.dynamodb}
+    second-dynamodb {
+      client {
+        # specific client settings here
+      }
+      journal {
+        # specific journal settings here
+      }
+      snapshot {
+        # specific snapshot settings here
+      }
+      query {
+        # specific query settings here
+      }
+    }
+    //#second-config
+    """)
+    .withFallback(TestConfig.config)
+    .resolve()
+
+  object MyEntity {
+    sealed trait Command
+    final case class Persist(payload: String, replyTo: ActorRef[State]) extends Command
+    type Event = String
+    object State {
+      def apply(): State = ""
+    }
+    type State = String
+
+    def commandHandler(state: State, cmd: Command): Effect[Event, State] = {
+      cmd match {
+        case Persist(payload, replyTo) =>
+          Effect
+            .persist(payload)
+            .thenReply(replyTo)(newState => newState)
+      }
+    }
+
+    def eventHandler(state: State, evt: Event): State =
+      state + evt
+
+    def apply(persistenceId: PersistenceId): EventSourcedBehavior[Command, Event, State] = {
+      //#with-plugins
+      EventSourcedBehavior(persistenceId, emptyState = State(), commandHandler, eventHandler)
+        .withJournalPluginId("second-dynamodb.journal")
+        .withSnapshotPluginId("second-dynamodb.snapshot")
+      //#with-plugins
+    }
+  }
+}
+
+class MultiPluginDocExample
+    extends ScalaTestWithActorTestKit(MultiPluginDocExample.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  import MultiPluginDocExample.MyEntity
+
+  override def typedSystem: ActorSystem[_] = system
+
+  "Addition DynamoDB plugin config" should {
+
+    "be supported for EventSourcedBehavior" in {
+      val probe = createTestProbe[MyEntity.State]()
+      val pid = PersistenceId.ofUniqueId(nextPid())
+      val ref = spawn(MyEntity(pid))
+      ref ! MyEntity.Persist("a", probe.ref)
+      probe.expectMessage("a")
+      ref ! MyEntity.Persist("b", probe.ref)
+      probe.expectMessage("ab")
+    }
+
+  }
+}

--- a/docs/src/test/scala/docs/scaladsl/QueryDocExample.scala
+++ b/docs/src/test/scala/docs/scaladsl/QueryDocExample.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+//#access-read-journal
+import akka.persistence.dynamodb.query.scaladsl.DynamoDBReadJournal
+import akka.persistence.query.PersistenceQuery
+
+//#access-read-journal
+
+//#current-events-by-slices
+import akka.persistence.query.NoOffset
+import akka.stream.scaladsl.Sink
+
+//#current-events-by-slices
+
+object QueryDocExample {
+  val config: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    akka.persistence.dynamodb {
+      client.local.enabled = true
+    }
+    """))
+
+  trait MyEvent
+}
+
+class QueryDocExample extends ScalaTestWithActorTestKit(QueryDocExample.config) with AnyWordSpecLike {
+  import QueryDocExample._
+
+  def accessReadJournal: DynamoDBReadJournal = {
+    //#access-read-journal
+    val eventQueries = PersistenceQuery(system)
+      .readJournalFor[DynamoDBReadJournal](DynamoDBReadJournal.Identifier)
+    //#access-read-journal
+    eventQueries
+  }
+
+  def currentEventsBySliceExampleCompileOnly(): Unit = {
+    val eventQueries = accessReadJournal
+
+    //#current-events-by-slices
+    // Split the slices into 4 ranges
+    val numberOfSliceRanges: Int = 4
+    val sliceRanges = eventQueries.sliceRanges(numberOfSliceRanges)
+
+    // Example of using the first slice range
+    val minSlice: Int = sliceRanges.head.min
+    val maxSlice: Int = sliceRanges.head.max
+    val entityType: String = "MyEntity"
+    eventQueries
+      .currentEventsBySlices[MyEvent](entityType, minSlice, maxSlice, NoOffset)
+      .map(envelope =>
+        s"event from persistenceId ${envelope.persistenceId} with " +
+        s"seqNr ${envelope.sequenceNr}: ${envelope.event}")
+      .runWith(Sink.foreach(println))
+    //#current-events-by-slices
+  }
+
+  "Query plugin docs" should {
+
+    "have example of accessing read journal (Scala)" in {
+      accessReadJournal shouldBe a[DynamoDBReadJournal]
+    }
+
+    "have example of accessing read journal (Java)" in {
+      val readJournal = docs.javadsl.QueryDocExample.accessReadJournal(system)
+      readJournal shouldBe an[akka.persistence.dynamodb.query.javadsl.DynamoDBReadJournal]
+    }
+
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,6 +69,10 @@ object Dependencies {
     TestDeps.logback,
     TestDeps.scalaTest)
 
-  val docs =
-    Seq(TestDeps.akkaPersistenceTyped)
+  val docs = Seq(
+    TestDeps.akkaPersistenceTyped,
+    TestDeps.akkaShardingTyped,
+    TestDeps.akkaJackson,
+    TestDeps.akkaTestkit,
+    TestDeps.scalaTest)
 }

--- a/samples/guide/shopping-cart-java/shopping-cart-service/src/main/java/shopping/cart/Main.java
+++ b/samples/guide/shopping-cart-java/shopping-cart-service/src/main/java/shopping/cart/Main.java
@@ -80,6 +80,16 @@ public class Main {
     }
 
     try {
+      akka.persistence.dynamodb.util.javadsl.CreateTables.createSnapshotsTable(
+                      system, DynamoDBSettings.create(system), client, false)
+              .toCompletableFuture().get(10, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      logger.info(e.toString());
+      // FIXME could be better error handling
+      // continue anyway, table may exist
+    }
+
+    try {
       akka.projection.dynamodb.javadsl.CreateTables.createTimestampOffsetStoreTable(
               system, DynamoDBProjectionSettings.create(system), client, false)
           .toCompletableFuture().get(10, TimeUnit.SECONDS);

--- a/scripts/create-tables.sh
+++ b/scripts/create-tables.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+#create-event-journal-table
 aws dynamodb create-table \
     --table-name event_journal \
     --attribute-definitions \
@@ -29,8 +30,9 @@ aws dynamodb create-table \
            }
         }
       ]'
+#create-event-journal-table
 
-
+#create-snapshot-table
 aws dynamodb create-table \
     --table-name snapshot \
     --attribute-definitions \
@@ -39,6 +41,7 @@ aws dynamodb create-table \
         AttributeName=pid,KeyType=HASH \
     --provisioned-throughput \
         ReadCapacityUnits=5,WriteCapacityUnits=5
+#create-snapshot-table
 
 aws dynamodb create-table \
     --table-name timestamp_offset \


### PR DESCRIPTION
Refs #49

Extend docs to cover the current functionality, based on the r2dbc docs. Describe required tables.