### PR TITLE
docs: add projection docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val docs = project
   .in(file("docs"))
   .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .disablePlugins(MimaPlugin, CiReleasePlugin)
-  .dependsOn(core % "compile;test->test")
+  .dependsOn(core % "compile;test->test", projection)
   .settings(common)
   .settings(dontPublish)
   .settings(

--- a/docs/src/main/paradox/config.md
+++ b/docs/src/main/paradox/config.md
@@ -54,3 +54,6 @@ Scala
 For queries and projection `SourceProvider` you would use `"second-dynamodb.query"` instead of the default
 @scala[`DynamoDBReadJournal.Identifier`]@java[`DynamoDBReadJournal.Identifier()`]
 (`"akka.persistence.dynamodb.query"`).
+
+For additional details on multiple plugin configuration for projections see the @ref:[Akka Projection DynamoDB
+docs](projection.md#multiple-plugins).

--- a/docs/src/main/paradox/getting-started.md
+++ b/docs/src/main/paradox/getting-started.md
@@ -74,3 +74,4 @@ See the table definitions in the individual plugins for more information on the 
 
 * @ref:[journal tables](journal.md#tables)
 * @ref:[snapshot tables](snapshots.md#tables)
+* @ref:[projection tables](projection.md#tables)

--- a/docs/src/main/paradox/projection.md
+++ b/docs/src/main/paradox/projection.md
@@ -1,3 +1,340 @@
 # Projection
 
-See @extref:[Akka Projection DynamoDB](akka-projection:dynamodb.html)
+<!-- Included in preview docs, until projections moved to akka-projection. -->
+<!-- See @extref:[Akka Projection DynamoDB](akka-projection:dynamodb.html) -->
+
+See @extref:[Akka Projection](akka-projection:index.html) for the main documentation on using Akka Projections.
+
+# Offset in DynamoDB
+
+<!-- TODO: @extref:[Akka Persistence DynamoDB](akka-persistence-dynamodb:overview.html) -->
+@apidoc[DynamoDBProjection$] has support for storing offsets in DynamoDB via @ref:[Akka Persistence DynamoDB](overview.md).
+
+The source of the envelopes is from a `SourceProvider`, which can be:
+
+<!-- TODO: @ref:[SourceProvider for eventsBySlices](eventsourced.md#sourceprovider-for-eventsbyslices) -->
+<!-- TODO: @extref:[eventsBySlices query](akka-persistence-r2dbc:query.html#eventsbyslices) -->
+* events from Event Sourced entities via the @extref:[SourceProvider for eventsBySlices](akka-projection:eventsourced.html#sourceprovider-for-eventsbyslices) with the @ref:[eventsBySlices query](query.md#eventsbyslices)
+
+The target database operations can run in the same transaction as storing the offset, so that
+@ref:[exactly-once](#exactly-once) processing semantics are supported. It also offers
+@ref:[at-least-once](#at-least-once) semantics.
+
+## Dependencies
+
+The Akka dependencies are available from Akka's library repository. To access them there, you need to configure the URL for this repository.
+
+@@repository [Maven,sbt,Gradle] {
+id="akka-repository"
+name="Akka library repository"
+url="https://repo.akka.io/maven"
+}
+
+To use the DynamoDB module of Akka Projections, add the following dependencies to your project:
+
+@@dependency [Maven,sbt,Gradle] {
+group=com.lightbend.akka
+artifact=akka-projection-dynamodb_$scala.binary.version$
+version=$project.version$
+group2=com.lightbend.akka
+artifact2=akka-persistence-dynamodb_$scala.binary.version$
+version2=$project.version$
+}
+
+Akka Projection DynamoDB depends on Akka $akka.version$ or later, and note that it is important that all `akka-*`
+dependencies are in the same version, so it is recommended to depend on them explicitly to avoid problems with
+transient dependencies causing an unlucky mix of versions.
+
+@@project-info{ projectId="projection" }
+
+### Transitive dependencies
+
+The table below shows `akka-projection-dynamodb`'s direct dependencies, and the second tab shows all libraries it depends on transitively.
+
+@@dependencies{ projectId="projection" }
+
+## Tables
+
+Akka Projection DynamoDB requires an offset table to be created in DynamoDB. The default table name is
+`timestamp_offset` and this can be configured (see the @ref:[reference configuration](#reference-configuration) for all
+settings). The table should be created with the following attributes and key schema:
+
+| Attribute name | Attribute type | Key type |
+| -------------- | -------------- | -------- |
+| name_slice     | S (String)     | HASH     |
+| pid            | S (String)     | RANGE    |
+
+Read and write capacity units should be based on expected projection activity.
+
+An example `aws` CLI command for creating the timestamp offset table:
+
+@@snip [aws create timestamp offset table](/scripts/create-tables.sh) { #create-timestamp-offset-table }
+
+### Creating tables locally
+
+The DynamoDB client @ref:[can be configured](config.md#dynamodb-client-configuration) with a local mode, for testing
+with DynamoDB local:
+
+@@snip [local mode](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #local-mode }
+
+Similar to @ref:[creating tables locally](getting-started.md#creating-tables-locally) for Akka Persistence DynamoDB, a
+@apidoc[akka.projection.dynamodb.*.CreateTables$] utility is provided for creating projection tables locally:
+
+Java
+: @@snip [create tables](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #create-tables }
+
+Scala
+: @@snip [create tables](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #create-tables }
+
+## Configuration
+
+By default, Akka Projection DynamoDB shares the @ref:[DynamoDB client configuration](config.md#dynamodb-client-configuration) with Akka Persistence DynamoDB.
+
+### Reference configuration
+
+The following can be overridden in your `application.conf` for projection specific settings:
+
+@@snip [reference.conf](/projection/src/main/resources/reference.conf) { #projection-config }
+
+## Running with Sharded Daemon Process
+
+The Sharded Daemon Process can be used to distribute `n` instances of a given Projection across the cluster.
+Therefore, it's important that each Projection instance consumes a subset of the stream of envelopes.
+
+When using `eventsBySlices` the initialization code looks like this:
+
+Java
+:  @@snip [init projections](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #init-projections }
+
+Scala
+:  @@snip [init projections](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #init-projections }
+
+The @ref:[`ShoppingCartTransactHandler` is shown below](#transact-handler).
+
+It is possible to dynamically scale the number of Projection instances as described in the @extref:[Sharded Daemon
+Process documentation](akka:typed/cluster-sharded-daemon-process.html#dynamic-scaling-of-number-of-workers).
+
+There are alternative ways of running the `ProjectionBehavior` as described in @extref:[Running a Projection](akka-projection:running.html).
+
+## Slices
+
+The `SourceProvider` for Event Sourced actors has historically been using `eventsByTag` but the DynamoDB plugin is
+instead providing `eventsBySlices` as an improved solution.
+
+The usage of `eventsByTag` for Projections has the drawback that the number of tags must be decided up-front and can't
+easily be changed afterwards. Starting with too many tags means a lot of overhead, since many projection instances
+would be running on each node in a small Akka Cluster, with each projection instance polling the database periodically.
+Starting with too few tags means that it can't be scaled later to more Akka nodes.
+
+With `eventsBySlices` more Projection instances can be added when needed and still reuse the offsets for the previous
+slice distributions.
+
+A slice is deterministically defined based on the persistence id. The purpose is to evenly distribute all
+persistence ids over the slices. The `eventsBySlices` query is for a range of the slices. For example if
+using 1024 slices and running 4 Projection instances the slice ranges would be 0-255, 256-511, 512-767, 768-1023.
+Changing to 8 slice ranges means that the ranges would be 0-127, 128-255, 256-383, ..., 768-895, 896-1023.
+
+However, when changing the number of slices the projections with the old slice distribution must be stopped before
+starting new projections. That can be done at runtime when @ref:[Running with Sharded Daemon
+Process](#running-with-sharded-daemon-process).
+
+When using `DynamoDBProjection` together with the `EventSourcedProvider.eventsBySlices` the events will be delivered in
+sequence number order without duplicates.
+
+## exactly-once
+
+The offset is stored in the same transaction as items returned by the projection handler, providing exactly-once
+processing semantics if the projection is restarted from a previously stored offset. A @apidoc[DynamoDBTransactHandler]
+is implemented, returning a collection of DynamoDB `TransactWriteItem`s which will be stored in the same transaction.
+
+Java
+:  @@snip [exactly once](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #projection-imports #exactly-once }
+
+Scala
+:  @@snip [exactly once](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #exactly-once }
+
+The @ref:[`ShoppingCartTransactHandler` is shown below](#transact-handler).
+
+## at-least-once
+
+The offset is stored after the envelope has been processed, providing at-least-once processing semantics. This means
+that if the projection is restarted from a previously stored offset some elements may be processed more than once.
+Therefore, the @ref:[Handler](#handler) code must be idempotent.
+
+Java
+:  @@snip [at least once](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #projection-imports #at-least-once }
+
+Scala
+:  @@snip [at least once](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #at-least-once }
+
+The offset is stored after a time window, or limited by a number of envelopes, whatever happens first. This window can
+be defined with `withSaveOffset` of the returned `AtLeastOnceProjection`. The default settings for the window is
+defined in the configuration section `akka.projection.at-least-once`. There is a performance benefit of not storing the
+offset too often, but the drawback is that there can be more duplicates that will be processed again when the
+projection is restarted.
+
+The @ref:[`ShoppingCartHandler` is shown below](#generic-handler).
+
+## exactly-once (grouped)
+
+The envelopes can be grouped before processing, which can be useful for batch updates.
+
+The offset is stored in the same transaction as items returned by the projection handler, providing exactly-once
+processing semantics if the projection is restarted from a previously stored offset. A @apidoc[DynamoDBTransactHandler]
+is implemented, returning a collection of DynamoDB `TransactWriteItem`s which will be stored in the same transaction.
+
+The envelopes are grouped within a time window, or limited by a number of envelopes, whatever happens first. This
+window can be defined using `withGroup` of the returned `GroupedProjection`. The default settings for the window is
+defined in the configuration section `akka.projection.grouped`.
+
+Java
+:  @@snip [exactly once grouped within](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #projection-imports #exactly-once-grouped-within }
+
+Scala
+:  @@snip [exactly once grouped within](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #exactly-once-grouped-within }
+
+The @ref:[`GroupedShoppingCartTransactHandler` is shown below](#grouped-transact-handler).
+
+## at-least-once (grouped)
+
+The envelopes can be grouped before processing, which can be useful for batch updates.
+
+The offsets are stored after the envelopes have been processed, providing at-least-once processing semantics. This
+means that if the projection is restarted from a previously stored offset some elements may be processed more than
+once. Therefore, the @ref:[Handler](#handler) code must be idempotent.
+
+The envelopes are grouped within a time window, or limited by a number of envelopes, whatever happens first. This
+window can be defined using `withGroup` of the returned `GroupedProjection`. The default settings for the window is
+defined in the configuration section `akka.projection.grouped`.
+
+Java
+:  @@snip [at least once grouped within](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #projection-imports #at-least-once-grouped-within }
+
+Scala
+:  @@snip [at least once grouped within](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #at-least-once-grouped-within }
+
+The @ref:[`GroupedShoppingCartHandler` is shown below](#grouped-handler).
+
+## Handler
+
+<!-- TODO: @apidoc[Handler] -->
+For at-least-once processing, a generic projection `Handler` is implemented and projections can do any processing, with
+or without DynamoDB.
+
+For exactly-once processing, a @apidoc[DynamoDBTransactHandler] is implemented, returning a collection of DynamoDB
+`TransactWriteItem`s which will be written in the same transaction as storing the offsets.
+
+### Generic handler
+
+<!-- TODO: @apidoc[Handler] -->
+A generic `Handler` that is consuming `ShoppingCart.Event` from `eventsBySlices` can look like this:
+
+Java
+:  @@snip [handler](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #handler }
+
+Scala
+:  @@snip [handler](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #handler }
+
+@@@ note { title=Hint }
+Simple handlers can also be defined as plain functions via the helper @scala[`Handler.apply`]@java[`Handler.fromFunction`] factory method.
+@@@
+
+### Transact handler
+
+A @apidoc[DynamoDBTransactHandler] that is consuming `ShoppingCart.Event` from `eventsBySlices` can look like this:
+
+Java
+:  @@snip [transact handler](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #transact-handler }
+
+Scala
+:  @@snip [transact handler](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #transact-handler }
+
+@@@ note { title=Hint }
+Simple handlers can also be defined as plain functions via the helper @scala[`DynamoDBTransactHandler.apply`]@java[`DynamoDBTransactHandler.fromFunction`] factory method.
+@@@
+
+### Grouped handler
+
+When using @ref:[`DynamoDBProjection.atLeastOnceGroupedWithin`](#at-least-once-grouped-) the handler is processing a @scala[`Seq`]@java[`List`] of envelopes.
+
+Java
+:  @@snip [grouped handler](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #grouped-handler }
+
+Scala
+:  @@snip [grouped handler](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #grouped-handler }
+
+### Grouped transact handler
+
+When using @ref:[`DynamoDBProjection.exactlyOnceGroupedWithin`](#exactly-once-grouped-) the
+@apidoc[DynamoDBTransactHandler] is processing a @scala[`Seq`]@java[`List`] of envelopes.
+
+Java
+:  @@snip [grouped handler](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #grouped-transact-handler }
+
+Scala
+:  @@snip [grouped handler](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #grouped-transact-handler }
+
+### Stateful handler
+
+<!-- TODO: @apidoc[Handler] -->
+The `Handler` or @apidoc[DynamoDBTransactHandler] can be stateful, with variables and mutable data structures. It is
+invoked by the `Projection` machinery one envelope or group of envelopes at a time and visibility guarantees between
+the invocations are handled automatically, i.e. no volatile or other concurrency primitives are needed for managing the
+state as long as it's not accessed by other threads than the one that called `process`.
+
+@@@ note
+It is important that the handler instance is not shared between several projection instances, because then it would be
+invoked concurrently, which is not how it is intended to be used. Each projection instance should use a new handler
+instance.
+@@@
+
+### Actor handler
+
+A good alternative for advanced state management is to implement the handler as an
+@extref:[actor](akka:typed/typed/actors.html) which is described in
+@extref:[Processing with Actor](akka-projection:actor.html).
+
+### Flow handler
+
+An Akka Streams `FlowWithContext` can be used instead of a handler for processing the envelopes, which is described in
+@extref:[Processing with Akka Streams](akka-projection:flow.html).
+
+### Handler lifecycle
+
+<!-- TODO: @apidoc[Handler] -->
+You can override the `start` and `stop` methods of the `Handler` or @apidoc[DynamoDBTransactHandler] to implement
+initialization before the first envelope is processed and resource cleanup when the projection is stopped. Those
+methods are also called when the projection is restarted after failure.
+
+See also @extref:[error handling](akka-projection:error.html).
+
+## Publish events for lower latency
+
+<!-- TODO: See @extref:[eventsBySlices documentation](akka-persistence-dynamodb:query.html#publish-events-for-lower-latency-of-eventsbyslices). -->
+
+See @ref:[eventsBySlices documentation](query.md#publish-events-for-lower-latency-of-eventsbyslices).
+
+## Multiple plugins
+
+Similar to how multiple plugins can be configured for the @ref[DynamoDB persistence
+plugin](config.md#multiple-plugins), multiple projection configurations are also possible.
+
+For the projection offset store you need an additional config section:
+
+@@snip [second config](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #second-projection-config }
+
+Note that the `use-client` property references the same client settings as used for the `second-dynamodb` plugins, but
+it could also have been a separate client configured as:
+
+@@snip [second config with client](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #second-projection-config-with-client }
+
+In this way, you can use the default plugins for the write side and projection `SourceProvider`, but use a separate configuration for the projection handlers and offset storage.
+
+You start the projections with @apidoc[DynamoDBProjectionSettings] loaded from `"second-projection-dynamodb"`.
+
+Java
+:  @@snip [projection settings](/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java) { #projection-settings }
+
+Scala
+:  @@snip [projection settings](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #projection-settings }
+

--- a/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java
+++ b/docs/src/test/java/projection/docs/javadsl/ProjectionDocExample.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package projection.docs.javadsl;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import akka.Done;
+import akka.actor.typed.ActorSystem;
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+import akka.serialization.jackson.CborSerializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// #create-tables
+import akka.persistence.dynamodb.util.ClientProvider;
+import akka.projection.dynamodb.DynamoDBProjectionSettings;
+import akka.projection.dynamodb.javadsl.CreateTables;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+// #create-tables
+
+// #handler
+// #grouped-handler
+import akka.projection.javadsl.Handler;
+// #grouped-handler
+// #handler
+
+// #transact-handler
+// #grouped-transact-handler
+import akka.projection.dynamodb.javadsl.DynamoDBTransactHandler;
+// #grouped-transact-handler
+// #transact-handler
+
+// #handler
+// #transact-handler
+// #grouped-handler
+// #grouped-transact-handler
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+// #grouped-transact-handler
+// #grouped-handler
+// #transact-handler
+// #handler
+
+// #init-projections
+import akka.cluster.sharding.typed.ShardedDaemonProcessSettings;
+import akka.cluster.sharding.typed.javadsl.ShardedDaemonProcess;
+import akka.japi.Pair;
+import akka.persistence.dynamodb.query.javadsl.DynamoDBReadJournal;
+import akka.persistence.query.Offset;
+import akka.persistence.query.typed.EventEnvelope;
+import akka.projection.Projection;
+import akka.projection.ProjectionBehavior;
+// #projection-imports
+import akka.projection.ProjectionId;
+import akka.projection.dynamodb.javadsl.DynamoDBProjection;
+// #projection-imports
+import akka.projection.eventsourced.javadsl.EventSourcedProvider;
+import akka.projection.javadsl.SourceProvider;
+
+import java.util.Optional;
+
+// #projection-imports
+
+// #projection-imports
+// #init-projections
+
+public class ProjectionDocExample {
+
+  public static void createTables(ActorSystem<?> system) throws Exception {
+    // #create-tables
+    String dynamoDBConfigPath = "akka.projection.dynamodb";
+
+    DynamoDBProjectionSettings settings =
+        DynamoDBProjectionSettings.create(system.settings().config().getConfig(dynamoDBConfigPath));
+
+    DynamoDbAsyncClient client = ClientProvider.get(system).clientFor(settings.useClient());
+
+    // create journal table, synchronously
+    CreateTables.createTimestampOffsetStoreTable(system, settings, client, /*deleteIfExists:*/ true)
+        .toCompletableFuture()
+        .get(10, TimeUnit.SECONDS);
+    // #create-tables
+  }
+
+  public static class ShoppingCart {
+    public static EntityTypeKey<Command> ENTITY_TYPE_KEY =
+        EntityTypeKey.create(Command.class, "ShoppingCart");
+
+    public interface Command extends CborSerializable {}
+
+    public interface Event {
+      String getCartId();
+    }
+
+    public static class CheckedOut implements Event {
+
+      public final String cartId;
+      public final Instant eventTime;
+
+      public CheckedOut(String cartId, Instant eventTime) {
+        this.cartId = cartId;
+        this.eventTime = eventTime;
+      }
+
+      public String getCartId() {
+        return cartId;
+      }
+
+      @Override
+      public String toString() {
+        return "CheckedOut(" + cartId + "," + eventTime + ")";
+      }
+    }
+  }
+
+  // #handler
+  public class ShoppingCartHandler extends Handler<EventEnvelope<ShoppingCart.Event>> {
+
+    private final DynamoDbAsyncClient client;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public ShoppingCartHandler(DynamoDbAsyncClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public CompletionStage<Done> process(EventEnvelope<ShoppingCart.Event> envelope) {
+      ShoppingCart.Event event = envelope.event();
+      if (event instanceof ShoppingCart.CheckedOut) {
+        ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+
+        logger.info(
+            "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+
+        Map<String, AttributeValue> attributes =
+            Map.of(
+                "id", AttributeValue.fromS(checkedOut.cartId),
+                "time", AttributeValue.fromN(String.valueOf(checkedOut.eventTime.toEpochMilli())));
+
+        CompletableFuture<PutItemResponse> response =
+            client.putItem(PutItemRequest.builder().tableName("orders").item(attributes).build());
+
+        return response.thenApply(__ -> Done.getInstance());
+
+      } else {
+        logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+        return CompletableFuture.completedFuture(Done.getInstance());
+      }
+    }
+  }
+
+  // #handler
+
+  // #transact-handler
+  public class ShoppingCartTransactHandler
+      implements DynamoDBTransactHandler<EventEnvelope<ShoppingCart.Event>> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public CompletionStage<Collection<TransactWriteItem>> process(
+        EventEnvelope<ShoppingCart.Event> envelope) {
+      ShoppingCart.Event event = envelope.event();
+      if (event instanceof ShoppingCart.CheckedOut) {
+        ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+
+        logger.info(
+            "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+
+        Map<String, AttributeValue> attributes =
+            Map.of(
+                "id", AttributeValue.fromS(checkedOut.cartId),
+                "time", AttributeValue.fromN(String.valueOf(checkedOut.eventTime.toEpochMilli())));
+
+        List<TransactWriteItem> items =
+            List.of(
+                TransactWriteItem.builder()
+                    .put(Put.builder().tableName("orders").item(attributes).build())
+                    .build());
+
+        return CompletableFuture.completedFuture(items);
+
+      } else {
+        logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+        return CompletableFuture.completedFuture(Collections.emptyList());
+      }
+    }
+  }
+
+  // #transact-handler
+
+  // #grouped-handler
+  public class GroupedShoppingCartHandler extends Handler<List<EventEnvelope<ShoppingCart.Event>>> {
+
+    private final DynamoDbAsyncClient client;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public GroupedShoppingCartHandler(DynamoDbAsyncClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public CompletionStage<Done> process(List<EventEnvelope<ShoppingCart.Event>> envelopes) {
+      List<WriteRequest> items =
+          envelopes.stream()
+              .flatMap(
+                  envelope -> {
+                    ShoppingCart.Event event = envelope.event();
+
+                    if (event instanceof ShoppingCart.CheckedOut) {
+                      ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+
+                      logger.info(
+                          "Shopping cart {} was checked out at {}",
+                          checkedOut.cartId,
+                          checkedOut.eventTime);
+
+                      Map<String, AttributeValue> attributes =
+                          Map.of(
+                              "id",
+                              AttributeValue.fromS(checkedOut.cartId),
+                              "time",
+                              AttributeValue.fromN(
+                                  String.valueOf(checkedOut.eventTime.toEpochMilli())));
+
+                      return Stream.of(
+                          WriteRequest.builder()
+                              .putRequest(PutRequest.builder().item(attributes).build())
+                              .build());
+
+                    } else {
+                      logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+                      return Stream.empty();
+                    }
+                  })
+              .collect(Collectors.toList());
+
+      CompletableFuture<BatchWriteItemResponse> response =
+          client.batchWriteItem(
+              BatchWriteItemRequest.builder().requestItems(Map.of("orders", items)).build());
+
+      return response.thenApply(__ -> Done.getInstance());
+    }
+  }
+
+  // #grouped-handler
+
+  // #grouped-transact-handler
+  public class GroupedShoppingCartTransactHandler
+      implements DynamoDBTransactHandler<List<EventEnvelope<ShoppingCart.Event>>> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public CompletionStage<Collection<TransactWriteItem>> process(
+        List<EventEnvelope<ShoppingCart.Event>> envelopes) {
+      List<TransactWriteItem> items =
+          envelopes.stream()
+              .flatMap(
+                  envelope -> {
+                    ShoppingCart.Event event = envelope.event();
+                    if (event instanceof ShoppingCart.CheckedOut) {
+                      ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+
+                      logger.info(
+                          "Shopping cart {} was checked out at {}",
+                          checkedOut.cartId,
+                          checkedOut.eventTime);
+
+                      Map<String, AttributeValue> attributes =
+                          Map.of(
+                              "id", AttributeValue.fromS(checkedOut.cartId),
+                              "time",
+                                  AttributeValue.fromN(
+                                      String.valueOf(checkedOut.eventTime.toEpochMilli())));
+
+                      return Stream.of(
+                          TransactWriteItem.builder()
+                              .put(Put.builder().tableName("orders").item(attributes).build())
+                              .build());
+
+                    } else {
+                      logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+                      return Stream.empty();
+                    }
+                  })
+              .collect(Collectors.toList());
+
+      return CompletableFuture.completedFuture(items);
+    }
+  }
+
+  // #grouped-transact-handler
+
+  public class InitExample {
+    private final ActorSystem<?> system;
+
+    public InitExample(ActorSystem<?> system) {
+      this.system = system;
+    }
+
+    // #init-projections
+    void initProjections() {
+      ShardedDaemonProcess.get(system)
+          .initWithContext(
+              ProjectionBehavior.Command.class,
+              "ShoppingCartProjection",
+              4,
+              daemonContext -> {
+                List<Pair<Integer, Integer>> sliceRanges =
+                    EventSourcedProvider.sliceRanges(
+                        system, DynamoDBReadJournal.Identifier(), daemonContext.totalProcesses());
+                Pair<Integer, Integer> sliceRange = sliceRanges.get(daemonContext.processNumber());
+                return ProjectionBehavior.create(createProjection(sliceRange));
+              },
+              ShardedDaemonProcessSettings.create(system),
+              Optional.of(ProjectionBehavior.stopMessage()));
+    }
+
+    Projection<EventEnvelope<ShoppingCart.Event>> createProjection(
+        Pair<Integer, Integer> sliceRange) {
+      int minSlice = sliceRange.first();
+      int maxSlice = sliceRange.second();
+
+      String entityType = ShoppingCart.ENTITY_TYPE_KEY.name();
+
+      SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider =
+          EventSourcedProvider.eventsBySlices(
+              system, DynamoDBReadJournal.Identifier(), entityType, minSlice, maxSlice);
+
+      ProjectionId projectionId =
+          ProjectionId.of("ShoppingCarts", "carts-" + minSlice + "-" + maxSlice);
+      Optional<DynamoDBProjectionSettings> settings = Optional.empty();
+
+      return DynamoDBProjection.exactlyOnce(
+          projectionId, settings, sourceProvider, ShoppingCartTransactHandler::new, system);
+    }
+    // #init-projections
+  }
+
+  public void exactlyOnceExample(
+      SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider,
+      int minSlice,
+      int maxSlice,
+      ActorSystem<?> system) {
+    // #exactly-once
+    ProjectionId projectionId =
+        ProjectionId.of("ShoppingCarts", "carts-" + minSlice + "-" + maxSlice);
+
+    Optional<DynamoDBProjectionSettings> settings = Optional.empty();
+
+    Projection<EventEnvelope<ShoppingCart.Event>> projection =
+        DynamoDBProjection.exactlyOnce(
+            projectionId, settings, sourceProvider, ShoppingCartTransactHandler::new, system);
+    // #exactly-once
+  }
+
+  public void atLeastOnceExample(
+      SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider,
+      int minSlice,
+      int maxSlice,
+      DynamoDbAsyncClient client,
+      ActorSystem<?> system) {
+    // #at-least-once
+    ProjectionId projectionId =
+        ProjectionId.of("ShoppingCarts", "carts-" + minSlice + "-" + maxSlice);
+
+    Optional<DynamoDBProjectionSettings> settings = Optional.empty();
+
+    int saveOffsetAfterEnvelopes = 100;
+    Duration saveOffsetAfterDuration = Duration.ofMillis(500);
+
+    Projection<EventEnvelope<ShoppingCart.Event>> projection =
+        DynamoDBProjection.atLeastOnce(
+                projectionId,
+                settings,
+                sourceProvider,
+                () -> new ShoppingCartHandler(client),
+                system)
+            .withSaveOffset(saveOffsetAfterEnvelopes, saveOffsetAfterDuration);
+    // #at-least-once
+  }
+
+  public void exactlyOnceGroupedWithinExample(
+      SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider,
+      int minSlice,
+      int maxSlice,
+      ActorSystem<?> system) {
+    // #exactly-once-grouped-within
+    ProjectionId projectionId =
+        ProjectionId.of("ShoppingCarts", "carts-" + minSlice + "-" + maxSlice);
+
+    Optional<DynamoDBProjectionSettings> settings = Optional.empty();
+
+    int groupAfterEnvelopes = 20;
+    Duration groupAfterDuration = Duration.ofMillis(500);
+
+    Projection<EventEnvelope<ShoppingCart.Event>> projection =
+        DynamoDBProjection.exactlyOnceGroupedWithin(
+                projectionId,
+                settings,
+                sourceProvider,
+                GroupedShoppingCartTransactHandler::new,
+                system)
+            .withGroup(groupAfterEnvelopes, groupAfterDuration);
+    // #exactly-once-grouped-within
+  }
+
+  public void atLeastOnceGroupedWithinExample(
+      SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider,
+      int minSlice,
+      int maxSlice,
+      DynamoDbAsyncClient client,
+      ActorSystem<?> system) {
+    // #at-least-once-grouped-within
+    ProjectionId projectionId =
+        ProjectionId.of("ShoppingCarts", "carts-" + minSlice + "-" + maxSlice);
+
+    Optional<DynamoDBProjectionSettings> settings = Optional.empty();
+
+    int groupAfterEnvelopes = 20;
+    Duration groupAfterDuration = Duration.ofMillis(500);
+
+    Projection<EventEnvelope<ShoppingCart.Event>> projection =
+        DynamoDBProjection.atLeastOnceGroupedWithin(
+                projectionId,
+                settings,
+                sourceProvider,
+                () -> new GroupedShoppingCartHandler(client),
+                system)
+            .withGroup(groupAfterEnvelopes, groupAfterDuration);
+    // #at-least-once-grouped-within
+  }
+
+  public void projectionWithSecondPlugin(
+      SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider,
+      int minSlice,
+      int maxSlice,
+      DynamoDbAsyncClient client,
+      ActorSystem<?> system) {
+    // #projection-settings
+    ProjectionId projectionId =
+        ProjectionId.of("ShoppingCarts", "carts-" + minSlice + "-" + maxSlice);
+
+    Optional<DynamoDBProjectionSettings> settings =
+        Optional.of(
+            DynamoDBProjectionSettings.create(
+                system.settings().config().getConfig("second-projection-dynamodb")));
+
+    Projection<EventEnvelope<ShoppingCart.Event>> projection =
+        DynamoDBProjection.atLeastOnce(
+            projectionId, settings, sourceProvider, () -> new ShoppingCartHandler(client), system);
+    // #projection-settings
+  }
+}

--- a/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala
+++ b/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala
@@ -1,0 +1,459 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package projection.docs.scaladsl
+
+import java.time.Instant
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
+import akka.persistence.query.Offset
+import akka.persistence.query.typed.EventEnvelope
+import akka.projection.scaladsl.SourceProvider
+import akka.serialization.jackson.CborSerializable
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Futures
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+object ProjectionDocExample {
+  val config: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    //#local-mode
+    akka.persistence.dynamodb {
+      client.local.enabled = true
+    }
+    //#local-mode
+    """))
+
+  object ShoppingCart {
+    val EntityKey: EntityTypeKey[Command] = EntityTypeKey[Command]("ShoppingCart")
+
+    sealed trait Command extends CborSerializable
+
+    sealed trait Event extends CborSerializable {
+      def cartId: String
+    }
+
+    final case class ItemAdded(cartId: String, itemId: String, quantity: Int) extends Event
+    final case class ItemRemoved(cartId: String, itemId: String) extends Event
+    final case class ItemQuantityAdjusted(cartId: String, itemId: String, newQuantity: Int) extends Event
+    final case class CheckedOut(cartId: String, eventTime: Instant) extends Event
+  }
+
+  object HandlerExample {
+    //#handler
+    import akka.Done
+    import akka.persistence.query.typed.EventEnvelope
+    import akka.projection.scaladsl.Handler
+    import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+    import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+
+    import scala.concurrent.Future
+    import scala.jdk.CollectionConverters._
+    import scala.jdk.FutureConverters._
+
+    class ShoppingCartHandler(client: DynamoDbAsyncClient)(implicit ec: ExecutionContext)
+        extends Handler[EventEnvelope[ShoppingCart.Event]] {
+      private val logger = LoggerFactory.getLogger(getClass)
+
+      override def process(envelope: EventEnvelope[ShoppingCart.Event]): Future[Done] = {
+        envelope.event match {
+          case ShoppingCart.CheckedOut(cartId, time) =>
+            logger.info(s"Shopping cart $cartId was checked out at $time")
+
+            val attributes = Map(
+              "id" -> AttributeValue.fromS(cartId),
+              "time" -> AttributeValue.fromN(time.toEpochMilli.toString)).asJava
+
+            client
+              .putItem(
+                PutItemRequest.builder
+                  .tableName("orders")
+                  .item(attributes)
+                  .build())
+              .asScala
+              .map(_ => Done)
+
+          case otherEvent =>
+            logger.debug(s"Shopping cart ${otherEvent.cartId} changed by $otherEvent")
+            Future.successful(Done)
+        }
+      }
+    }
+    //#handler
+  }
+
+  object TransactHandlerExample {
+    //#transact-handler
+    import akka.persistence.query.typed.EventEnvelope
+    import akka.projection.dynamodb.scaladsl.DynamoDBTransactHandler
+    import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+    import software.amazon.awssdk.services.dynamodb.model.Put
+    import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+
+    import scala.concurrent.Future
+    import scala.jdk.CollectionConverters._
+
+    class ShoppingCartTransactHandler extends DynamoDBTransactHandler[EventEnvelope[ShoppingCart.Event]] {
+      private val logger = LoggerFactory.getLogger(getClass)
+
+      override def process(envelope: EventEnvelope[ShoppingCart.Event]): Future[Iterable[TransactWriteItem]] = {
+        envelope.event match {
+          case ShoppingCart.CheckedOut(cartId, time) =>
+            logger.info(s"Shopping cart $cartId was checked out at $time")
+
+            val attributes = Map(
+              "id" -> AttributeValue.fromS(cartId),
+              "time" -> AttributeValue.fromN(time.toEpochMilli.toString)).asJava
+
+            Future.successful(
+              Seq(
+                TransactWriteItem.builder
+                  .put(
+                    Put.builder
+                      .tableName("orders")
+                      .item(attributes)
+                      .build())
+                  .build()))
+
+          case otherEvent =>
+            logger.debug(s"Shopping cart ${otherEvent.cartId} changed by $otherEvent")
+            Future.successful(Seq.empty)
+        }
+      }
+    }
+    //#transact-handler
+  }
+
+  object GroupedHandlerExample {
+    //#grouped-handler
+    import akka.Done
+    import akka.persistence.query.typed.EventEnvelope
+    import akka.projection.scaladsl.Handler
+    import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+    import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest
+    import software.amazon.awssdk.services.dynamodb.model.PutRequest
+    import software.amazon.awssdk.services.dynamodb.model.WriteRequest
+
+    import scala.concurrent.Future
+    import scala.jdk.CollectionConverters._
+    import scala.jdk.FutureConverters._
+
+    class GroupedShoppingCartHandler(client: DynamoDbAsyncClient)(implicit ec: ExecutionContext)
+        extends Handler[Seq[EventEnvelope[ShoppingCart.Event]]] {
+      private val logger = LoggerFactory.getLogger(getClass)
+
+      override def process(envelopes: Seq[EventEnvelope[ShoppingCart.Event]]): Future[Done] = {
+        val items = envelopes.flatMap { envelope =>
+          envelope.event match {
+            case ShoppingCart.CheckedOut(cartId, time) =>
+              logger.info(s"Shopping cart $cartId was checked out at $time")
+
+              val attributes =
+                Map(
+                  "id" -> AttributeValue.fromS(cartId),
+                  "time" -> AttributeValue.fromN(time.toEpochMilli.toString)).asJava
+
+              Some(
+                WriteRequest.builder
+                  .putRequest(
+                    PutRequest.builder
+                      .item(attributes)
+                      .build())
+                  .build())
+
+            case otherEvent =>
+              logger.debug(s"Shopping cart ${otherEvent.cartId} changed by $otherEvent")
+              None
+          }
+        }.asJava
+
+        client
+          .batchWriteItem(
+            BatchWriteItemRequest.builder
+              .requestItems(Map("orders" -> items).asJava)
+              .build())
+          .asScala
+          .map(_ => Done)
+      }
+    }
+    //#grouped-handler
+  }
+
+  object GroupedTransactHandlerExample {
+    //#grouped-transact-handler
+    import akka.persistence.query.typed.EventEnvelope
+    import akka.projection.dynamodb.scaladsl.DynamoDBTransactHandler
+    import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+    import software.amazon.awssdk.services.dynamodb.model.Put
+    import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+
+    import scala.concurrent.Future
+    import scala.jdk.CollectionConverters._
+
+    class GroupedShoppingCartTransactHandler extends DynamoDBTransactHandler[Seq[EventEnvelope[ShoppingCart.Event]]] {
+      private val logger = LoggerFactory.getLogger(getClass)
+
+      override def process(envelopes: Seq[EventEnvelope[ShoppingCart.Event]]): Future[Iterable[TransactWriteItem]] = {
+        val items = envelopes.flatMap { envelope =>
+          envelope.event match {
+            case ShoppingCart.CheckedOut(cartId, time) =>
+              logger.info(s"Shopping cart $cartId was checked out at $time")
+
+              val attributes = Map(
+                "id" -> AttributeValue.fromS(cartId),
+                "time" -> AttributeValue.fromN(time.toEpochMilli.toString)).asJava
+
+              Seq(
+                TransactWriteItem.builder
+                  .put(
+                    Put.builder
+                      .tableName("orders")
+                      .item(attributes)
+                      .build())
+                  .build())
+
+            case otherEvent =>
+              logger.debug(s"Shopping cart ${otherEvent.cartId} changed by $otherEvent")
+              Seq.empty
+          }
+        }
+        Future.successful(items)
+      }
+    }
+    //#grouped-transact-handler
+  }
+
+  def initExample(implicit system: ActorSystem[_]): Unit = {
+    import TransactHandlerExample.ShoppingCartTransactHandler
+
+    //#init-projections
+    import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
+    import akka.cluster.sharding.typed.scaladsl.ShardedDaemonProcess
+    import akka.persistence.dynamodb.query.scaladsl.DynamoDBReadJournal
+    import akka.persistence.query.typed.EventEnvelope
+    import akka.projection.Projection
+    import akka.projection.ProjectionBehavior
+    import akka.projection.ProjectionId
+    import akka.projection.dynamodb.scaladsl.DynamoDBProjection
+    import akka.projection.eventsourced.scaladsl.EventSourcedProvider
+    import akka.projection.scaladsl.SourceProvider
+
+    def sourceProvider(sliceRange: Range): SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]] =
+      EventSourcedProvider.eventsBySlices[ShoppingCart.Event](
+        system,
+        readJournalPluginId = DynamoDBReadJournal.Identifier,
+        ShoppingCart.EntityKey.name,
+        sliceRange.min,
+        sliceRange.max)
+
+    def projection(sliceRange: Range): Projection[EventEnvelope[ShoppingCart.Event]] = {
+      val minSlice = sliceRange.min
+      val maxSlice = sliceRange.max
+      val projectionId = ProjectionId("ShoppingCarts", s"carts-$minSlice-$maxSlice")
+
+      DynamoDBProjection.exactlyOnce(
+        projectionId,
+        settings = None,
+        sourceProvider(sliceRange),
+        handler = () => new ShoppingCartTransactHandler)
+    }
+
+    ShardedDaemonProcess(system).initWithContext(
+      name = "ShoppingCartProjection",
+      initialNumberOfInstances = 4,
+      behaviorFactory = { daemonContext =>
+        val sliceRanges =
+          EventSourcedProvider.sliceRanges(system, DynamoDBReadJournal.Identifier, daemonContext.totalProcesses)
+        val sliceRange = sliceRanges(daemonContext.processNumber)
+        ProjectionBehavior(projection(sliceRange))
+      },
+      ShardedDaemonProcessSettings(system),
+      stopMessage = ProjectionBehavior.Stop)
+    //#init-projections
+  }
+
+  def exactlyOnceExample(
+      sourceProvider: SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]],
+      minSlice: Int,
+      maxSlice: Int)(implicit system: ActorSystem[_]): Unit = {
+    import TransactHandlerExample.ShoppingCartTransactHandler
+
+    //#exactly-once
+    import akka.projection.ProjectionId
+    import akka.projection.dynamodb.scaladsl.DynamoDBProjection
+
+    val projectionId = ProjectionId("ShoppingCarts", s"carts-$minSlice-$maxSlice")
+
+    val projection = DynamoDBProjection.exactlyOnce(
+      projectionId,
+      settings = None,
+      sourceProvider,
+      handler = () => new ShoppingCartTransactHandler)
+    //#exactly-once
+  }
+
+  def atLeastOnceExample(
+      sourceProvider: akka.projection.scaladsl.SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]],
+      minSlice: Int,
+      maxSlice: Int,
+      client: DynamoDbAsyncClient)(implicit system: ActorSystem[_], ec: ExecutionContext): Unit = {
+    import HandlerExample.ShoppingCartHandler
+
+    //#at-least-once
+    import akka.projection.ProjectionId
+    import akka.projection.dynamodb.scaladsl.DynamoDBProjection
+
+    val projectionId = ProjectionId("ShoppingCarts", s"carts-$minSlice-$maxSlice")
+
+    val projection =
+      DynamoDBProjection
+        .atLeastOnce(projectionId, settings = None, sourceProvider, handler = () => new ShoppingCartHandler(client))
+        .withSaveOffset(afterEnvelopes = 100, afterDuration = 500.millis)
+    //#at-least-once
+  }
+
+  def exactlyOnceGroupedWithinExample(
+      sourceProvider: akka.projection.scaladsl.SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]],
+      minSlice: Int,
+      maxSlice: Int)(implicit system: ActorSystem[_]): Unit = {
+    import GroupedTransactHandlerExample.GroupedShoppingCartTransactHandler
+
+    //#exactly-once-grouped-within
+    import akka.projection.ProjectionId
+    import akka.projection.dynamodb.scaladsl.DynamoDBProjection
+
+    val projectionId = ProjectionId("ShoppingCarts", s"carts-$minSlice-$maxSlice")
+
+    val projection =
+      DynamoDBProjection
+        .exactlyOnceGroupedWithin(
+          projectionId,
+          settings = None,
+          sourceProvider,
+          handler = () => new GroupedShoppingCartTransactHandler)
+        .withGroup(groupAfterEnvelopes = 20, groupAfterDuration = 500.millis)
+    //#exactly-once-grouped-within
+  }
+
+  def atLeastOnceGroupedWithinExample(
+      sourceProvider: akka.projection.scaladsl.SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]],
+      minSlice: Int,
+      maxSlice: Int,
+      client: DynamoDbAsyncClient)(implicit system: ActorSystem[_], ec: ExecutionContext): Unit = {
+    import GroupedHandlerExample.GroupedShoppingCartHandler
+
+    //#at-least-once-grouped-within
+    import akka.projection.ProjectionId
+    import akka.projection.dynamodb.scaladsl.DynamoDBProjection
+
+    val projectionId = ProjectionId("ShoppingCarts", s"carts-$minSlice-$maxSlice")
+
+    val projection =
+      DynamoDBProjection
+        .atLeastOnceGroupedWithin(
+          projectionId,
+          settings = None,
+          sourceProvider,
+          handler = () => new GroupedShoppingCartHandler(client))
+        .withGroup(groupAfterEnvelopes = 20, groupAfterDuration = 500.millis)
+    //#at-least-once-grouped-within
+  }
+
+  object MultiPluginExample {
+    val config =
+      """
+      // #second-projection-config
+      second-projection-dynamodb = ${akka.projection.dynamodb}
+      second-projection-dynamodb {
+        offset-store {
+          # specific projection offset store settings here
+        }
+        use-client = "second-dynamodb.client"
+      }
+      // #second-projection-config
+
+      // #second-projection-config-with-client
+      second-projection-dynamodb = ${akka.projection.dynamodb}
+      second-projection-dynamodb {
+        offset-store {
+          # specific projection offset store settings here
+        }
+        client = ${akka.persistence.dynamodb.client}
+        client {
+          # specific client settings for offset store and projection handler here
+        }
+        use-client = "second-projection-dynamodb.client"
+      }
+      // #second-projection-config-with-client
+      """
+
+    def projectionWithSecondPlugin(
+        sourceProvider: akka.projection.scaladsl.SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]],
+        minSlice: Int,
+        maxSlice: Int,
+        client: DynamoDbAsyncClient)(implicit system: ActorSystem[_], ec: ExecutionContext): Unit = {
+      import HandlerExample.ShoppingCartHandler
+
+      //#projection-settings
+      import akka.projection.ProjectionId
+      import akka.projection.dynamodb.DynamoDBProjectionSettings
+      import akka.projection.dynamodb.scaladsl.DynamoDBProjection
+
+      val projectionId = ProjectionId("ShoppingCarts", s"carts-$minSlice-$maxSlice")
+
+      val settings = Some(DynamoDBProjectionSettings(system.settings.config.getConfig("second-projection-dynamodb")))
+
+      val projection =
+        DynamoDBProjection.atLeastOnce(
+          projectionId,
+          settings,
+          sourceProvider,
+          handler = () => new ShoppingCartHandler(client))
+      //#projection-settings
+    }
+  }
+}
+
+class ProjectionDocExample
+    extends ScalaTestWithActorTestKit(ProjectionDocExample.config)
+    with AnyWordSpecLike
+    with Futures {
+
+  "Projection docs" should {
+
+    "have example of creating tables locally (Scala)" in {
+      //#create-tables
+      import akka.persistence.dynamodb.util.ClientProvider
+      import akka.projection.dynamodb.DynamoDBProjectionSettings
+      import akka.projection.dynamodb.scaladsl.CreateTables
+      import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+      val dynamoDBConfigPath = "akka.projection.dynamodb"
+
+      val settings: DynamoDBProjectionSettings =
+        DynamoDBProjectionSettings(system.settings.config.getConfig(dynamoDBConfigPath))
+
+      val client: DynamoDbAsyncClient = ClientProvider(system).clientFor(settings.useClient)
+
+      // create timestamp offset table, synchronously
+      Await.result(
+        CreateTables.createTimestampOffsetStoreTable(system, settings, client, deleteIfExists = true),
+        10.seconds)
+      //#create-tables
+    }
+
+    "have example of creating tables locally (Java)" in {
+      projection.docs.javadsl.ProjectionDocExample.createTables(system)
+    }
+
+  }
+}

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -32,4 +32,15 @@ project-info {
       }
     ]
   }
+  projection: ${project-info.shared-info} {
+    title: "Akka Projection DynamoDB"
+    jpms-name: "akka.projection.dynamodb"
+    levels: [
+      {
+        readiness: "Incubating"
+        since: "2024-05-23"
+        since-version: "0.1"
+      }
+    ]
+  }
 }

--- a/scripts/create-tables.sh
+++ b/scripts/create-tables.sh
@@ -43,6 +43,7 @@ aws dynamodb create-table \
         ReadCapacityUnits=5,WriteCapacityUnits=5
 #create-snapshot-table
 
+#create-timestamp-offset-table
 aws dynamodb create-table \
     --table-name timestamp_offset \
     --attribute-definitions \
@@ -53,6 +54,7 @@ aws dynamodb create-table \
         AttributeName=pid,KeyType=RANGE \
     --provisioned-throughput \
         ReadCapacityUnits=5,WriteCapacityUnits=5
+#create-timestamp-offset-table
 
 aws dynamodb create-table \
     --table-name projection_spec \


### PR DESCRIPTION
Refs #49 

Add docs for projections, adapted from the r2dbc docs for DynamoDB. These docs will be moved to `akka-projection` along with the code. Making projection docs available for preview releases.