### PR TITLE
feat: extend dynamodb client configuration

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -108,6 +108,75 @@ akka.persistence.dynamodb {
     # It should be set lower than the circuit-breaker.call-timeout.
     call-timeout = 9 seconds
 
+    # The amount of time to wait for each API request to complete before giving up and timing out.
+    # Can be used together with `call-timeout` to enforce both a timeout on each individual HTTP request
+    # (i.e. each retry) and the total time spent on all requests across retries (i.e. the 'API call' time).
+    # Disabled when set to `off` or `none`.
+    call-attempt-timeout = none
+
+    # HTTP client settings.
+    http {
+      # Maximum number of allowed concurrent requests.
+      max-concurrency = 50
+
+      # The maximum number of pending acquires allowed.
+      max-pending-connection-acquires = 10000
+
+      # The amount of time to wait for a read before an exception is thrown.
+      read-timeout = 30 seconds
+
+      # The amount of time to wait for a write before an exception is thrown.
+      write-timeout = 30 seconds
+
+      # The amount of time to wait when initially establishing a connection before giving up and timing out.
+      connection-timeout = 2 seconds
+
+      # The amount of time to wait when acquiring a connection from the pool before giving up and timing out.
+      connection-acquisition-timeout = 10 seconds
+
+      # The maximum amount of time that a connection should be allowed to remain open, regardless of usage frequency.
+      # Zero indicates an infinite amount of time.
+      connection-time-to-live = 0
+
+      # Configure whether idle connections in the connection pool should be closed.
+      # Set `connection-max-idle-time` for amount of idle time that should be allowed.
+      use-idle-connection-reaper = true
+
+      # The maximum amount of time that a connection should be allowed to remain open while idle.
+      # Enabled with `use-idle-connection-reaper`.
+      connection-max-idle-time = 60 seconds
+
+      # Configure the maximum amount of time that a TLS handshake is allowed to take.
+      tls-negotiation-timeout = 5 seconds
+
+      # Whether to enable or disable TCP KeepAlive.
+      tcp-keep-alive = false
+    }
+
+    # Retry policy settings.
+    retry-policy {
+      # Whether retries are enabled.
+      enabled = on
+
+      # Set the retry mode. Can be `default`, `legacy`, `standard`, or `adaptive`.
+      # See the documentation for the AWS SDK for Java for details.
+      retry-mode = default
+
+      # Maximum number of times that a single request should be retried, assuming it fails for a retryable error.
+      # Can be `default` for the default number of retries for the `retry-mode`, or override with a specific number.
+      num-retries = default
+    }
+
+    # Request compression settings.
+    compression {
+      # Whether request compression is enabled.
+      enabled = on
+
+      # Minimum compression threshold, inclusive, in bytes. A request whose size is less than the threshold
+      # will not be compressed. The value must be non-negative and no greater than 10 MiB (10,485,760 B).
+      threshold = 10 KiB
+    }
+
     # Configure the region of the DynamoDB instance.
     #
     # If this setting is not specified, then the default region lookup for the DynamoDB client will be used:

--- a/core/src/test/scala/akka/persistence/dynamodb/util/ClientProviderSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/util/ClientProviderSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.dynamodb.util
+
+import scala.concurrent.duration._
+import scala.jdk.OptionConverters._
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.ActorTestKitBase
+import akka.util.JavaDurationConverters._
+import com.typesafe.config.ConfigFactory
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import software.amazon.awssdk.core.retry.RetryMode
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+class ClientProviderSpec extends AnyWordSpec with Matchers with OptionValues {
+
+  "ClientProvider" should {
+
+    "create client with default settings" in withActorTestKit("""
+      akka.persistence.dynamodb.client {
+        # region usually picked up automatically, set manually for test
+        region = "us-east-1"
+      }
+      """) { testKit =>
+      val clientConfigLocation = "akka.persistence.dynamodb.client"
+      val settings = ClientProvider(testKit.system).clientSettingsFor(clientConfigLocation)
+      val client = ClientProvider(testKit.system).clientFor(clientConfigLocation)
+      client shouldBe a[DynamoDbAsyncClient]
+
+      val clientConfiguration = client.serviceClientConfiguration
+      clientConfiguration.region shouldBe Region.US_EAST_1
+
+      val overrideConfiguration = clientConfiguration.overrideConfiguration
+      overrideConfiguration.apiCallTimeout.toScala shouldBe Some(9.seconds.asJava)
+      overrideConfiguration.apiCallAttemptTimeout.toScala shouldBe None
+
+      val httpSettings = settings.http
+      httpSettings.maxConcurrency shouldBe 50
+      httpSettings.maxPendingConnectionAcquires shouldBe 10000
+      httpSettings.readTimeout shouldBe 30.seconds
+      httpSettings.writeTimeout shouldBe 30.seconds
+      httpSettings.connectionTimeout shouldBe 2.seconds
+      httpSettings.connectionAcquisitionTimeout shouldBe 10.seconds
+      httpSettings.connectionTimeToLive shouldBe 0.seconds
+      httpSettings.useIdleConnectionReaper shouldBe true
+      httpSettings.connectionMaxIdleTime shouldBe 60.seconds
+      httpSettings.tlsNegotiationTimeout shouldBe 5.seconds
+      httpSettings.tcpKeepAlive shouldBe false
+
+      val retryPolicy = overrideConfiguration.retryPolicy.toScala.value
+      retryPolicy.retryMode shouldBe RetryMode.LEGACY
+      retryPolicy.numRetries shouldBe 3
+
+      val compressionConfiguration = overrideConfiguration.compressionConfiguration.toScala.value
+      compressionConfiguration.requestCompressionEnabled shouldBe true
+      compressionConfiguration.minimumCompressionThresholdInBytes shouldBe 10240
+    }
+
+    "create client with configured settings" in withActorTestKit("""
+      akka.persistence.dynamodb.client {
+        call-timeout = 3 seconds
+        call-attempt-timeout = 500 millis
+
+        http {
+          max-concurrency = 100
+          max-pending-connection-acquires = 100000
+          read-timeout = 10 seconds
+          write-timeout = 10 seconds
+          connection-timeout = 5 seconds
+          connection-acquisition-timeout = 5 seconds
+          connection-time-to-live = 30 seconds
+          use-idle-connection-reaper = false
+          connection-max-idle-time = 30 seconds
+          tls-negotiation-timeout = 10 seconds
+          tcp-keep-alive = true
+        }
+
+        retry-policy {
+          retry-mode = standard
+          num-retries = 5
+        }
+
+        compression {
+          enabled = off
+          threshold = 20 KiB
+        }
+
+        # region usually picked up automatically, set manually for test
+        region = "us-east-1"
+      }
+      """) { testKit =>
+      val clientConfigLocation = "akka.persistence.dynamodb.client"
+      val settings = ClientProvider(testKit.system).clientSettingsFor(clientConfigLocation)
+      val client = ClientProvider(testKit.system).clientFor(clientConfigLocation)
+      client shouldBe a[DynamoDbAsyncClient]
+
+      val clientConfiguration = client.serviceClientConfiguration
+      clientConfiguration.region shouldBe Region.US_EAST_1
+
+      val overrideConfiguration = clientConfiguration.overrideConfiguration
+      overrideConfiguration.apiCallTimeout.toScala shouldBe Some(3.seconds.asJava)
+      overrideConfiguration.apiCallAttemptTimeout.toScala shouldBe Some(500.millis.asJava)
+
+      val httpSettings = settings.http
+      httpSettings.maxConcurrency shouldBe 100
+      httpSettings.maxPendingConnectionAcquires shouldBe 100000
+      httpSettings.readTimeout shouldBe 10.seconds
+      httpSettings.writeTimeout shouldBe 10.seconds
+      httpSettings.connectionTimeout shouldBe 5.seconds
+      httpSettings.connectionAcquisitionTimeout shouldBe 5.seconds
+      httpSettings.connectionTimeToLive shouldBe 30.seconds
+      httpSettings.useIdleConnectionReaper shouldBe false
+      httpSettings.connectionMaxIdleTime shouldBe 30.seconds
+      httpSettings.tlsNegotiationTimeout shouldBe 10.seconds
+      httpSettings.tcpKeepAlive shouldBe true
+
+      val retryPolicy = overrideConfiguration.retryPolicy.toScala.value
+      retryPolicy.retryMode shouldBe RetryMode.STANDARD
+      retryPolicy.numRetries shouldBe 5
+
+      val compressionConfiguration = overrideConfiguration.compressionConfiguration.toScala.value
+      compressionConfiguration.requestCompressionEnabled shouldBe false
+      compressionConfiguration.minimumCompressionThresholdInBytes shouldBe 20480
+    }
+
+    "create client with no retry policy if configured" in withActorTestKit("""
+      akka.persistence.dynamodb.client {
+        retry-policy {
+          enabled = off
+        }
+        
+        # region usually picked up automatically, set manually for test
+        region = "us-east-1"
+      }
+      """) { testKit =>
+      val clientConfigLocation = "akka.persistence.dynamodb.client"
+      val client = ClientProvider(testKit.system).clientFor(clientConfigLocation)
+      client shouldBe a[DynamoDbAsyncClient]
+
+      val overrideConfiguration = client.serviceClientConfiguration.overrideConfiguration
+      val retryPolicy = overrideConfiguration.retryPolicy.toScala.value
+      retryPolicy.retryMode shouldBe RetryMode.LEGACY
+      retryPolicy.numRetries shouldBe 0
+    }
+  }
+
+  def withActorTestKit(conf: String = "")(test: ActorTestKit => Unit): Unit = {
+    val config = ConfigFactory.load(ConfigFactory.parseString(conf))
+    val testKit = ActorTestKit(ActorTestKitBase.testNameFromCallStack(), config)
+    try test(testKit)
+    finally testKit.shutdownTestKit()
+  }
+
+}


### PR DESCRIPTION
Extend to more of the possible DynamoDB client configuration.

Reference config has the defaults from the AWS SDK. Haven't adjusted the http timeouts to be within the API call timeout, within the circuit breaker timeout. But we could do that. At the moment these just mirror the client defaults, and the overall call timeout would take effect first.