### PR TITLE
feat: event sourced cleanup tool

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -109,6 +109,16 @@ akka.persistence.dynamodb {
 }
 // #query-settings
 
+// #cleanup-settings
+akka.persistence.dynamodb {
+  # Cleanup tool settings.
+  cleanup {
+    # Log progress after this number of delete operations. Can be set to 1 to log progress of each operation.
+    log-progress-every = 100
+  }
+}
+// #cleanup-settings
+
 // #client-settings
 akka.persistence.dynamodb {
   client {

--- a/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
@@ -39,7 +39,9 @@ object DynamoDBSettings {
 
     val querySettings = new QuerySettings(config.getConfig("query"))
 
-    new DynamoDBSettings(journalTable, journalPublishEvents, snapshotTable, querySettings)
+    val cleanupSettings = new CleanupSettings(config.getConfig("cleanup"))
+
+    new DynamoDBSettings(journalTable, journalPublishEvents, snapshotTable, querySettings, cleanupSettings)
   }
 
   /**
@@ -54,7 +56,8 @@ final class DynamoDBSettings private (
     val journalTable: String,
     val journalPublishEvents: Boolean,
     val snapshotTable: String,
-    val querySettings: QuerySettings) {
+    val querySettings: QuerySettings,
+    val cleanupSettings: CleanupSettings) {
 
   val journalBySliceGsi: String = journalTable + "_slice_idx"
   val snapshotBySliceGsi: String = snapshotTable + "_slice_idx"
@@ -228,4 +231,12 @@ final class ClientSettings(
 final class PublishEventsDynamicSettings(config: Config) {
   val throughputThreshold: Int = config.getInt("throughput-threshold")
   val throughputCollectInterval: FiniteDuration = config.getDuration("throughput-collect-interval").toScala
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+final class CleanupSettings(config: Config) {
+  val logProgressEvery: Int = config.getInt("log-progress-every")
 }

--- a/core/src/main/scala/akka/persistence/dynamodb/cleanup/javadsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/cleanup/javadsl/EventSourcedCleanup.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.dynamodb.cleanup.javadsl
+
+import java.util.concurrent.CompletionStage
+import java.util.{ List => JList }
+
+import scala.compat.java8.FutureConverters._
+import scala.jdk.CollectionConverters._
+
+import akka.Done
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.ApiMayChange
+import akka.persistence.dynamodb.cleanup.scaladsl
+
+/**
+ * Java API: Tool for deleting events and/or snapshots for a given list of `persistenceIds` without using persistent
+ * actors.
+ *
+ * When running an operation with `EventSourcedCleanup` that deletes all events for a persistence id, the actor with
+ * that persistence id must not be running! If the actor is restarted it would in that case be recovered to the wrong
+ * state since the stored events have been deleted. Delete events before snapshot can still be used while the actor is
+ * running.
+ *
+ * If `resetSequenceNumber` is `true` then an entity created with the same `persistenceId` will start from 0. Otherwise
+ * it will continue from the latest highest used sequence number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the sequence number should be avoided, since it might be
+ * confusing to reuse the same sequence number for new events.
+ *
+ * When a list of `persistenceIds` are given, they are deleted sequentially in the same order as the list. It's possible
+ * to parallelize the deletes by running several cleanup operations at the same time, each operating on different sets
+ * of `persistenceIds`.
+ */
+@ApiMayChange
+final class EventSourcedCleanup private (delegate: scaladsl.EventSourcedCleanup) {
+
+  def this(systemProvider: ClassicActorSystemProvider, configPath: String) =
+    this(new scaladsl.EventSourcedCleanup(systemProvider, configPath))
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "akka.persistence.dynamodb.cleanup")
+
+  /**
+   * Delete all events before a sequenceNr for the given persistence id. Snapshots are not deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param toSequenceNr
+   *   sequence nr (inclusive) to delete up to
+   */
+  def deleteEventsTo(persistenceId: String, toSequenceNr: Long): CompletionStage[Done] =
+    delegate.deleteEventsTo(persistenceId, toSequenceNr).toJava
+
+  /**
+   * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAllEvents(persistenceId, resetSequenceNumber).toJava
+
+  /**
+   * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber).toJava
+
+  // TODO: Delete before timestamp operations.
+  //
+  // /**
+  //  * Delete events before a timestamp for the given persistence id. Snapshots are not deleted.
+  //  *
+  //  * This can be useful for `DurableStateBehavior` with change events, where the events are only used for the
+  //  * Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the
+  //  * offset timestamp of the Projections, if events are not needed after all Projections have processed them.
+  //  *
+  //  * Be aware of that if all events of a persistenceId are removed the sequence number will start from 1 again if an
+  //  * `EventSourcedBehavior` with the same persistenceId is used again.
+  //  *
+  //  * @param persistenceId
+  //  *   the persistence id to delete for
+  //  * @param timestamp
+  //  *   timestamp (exclusive) to delete up to
+  //  */
+  // def deleteEventsBefore(persistenceId: String, timestamp: Instant): CompletionStage[Done] =
+  //   delegate.deleteEventsBefore(persistenceId, timestamp).toJava
+
+  // TODO: Delete before timestamp operations.
+  //
+  // /**
+  //  * Delete events before a timestamp for the given entityType and slice. Snapshots are not deleted.
+  //  *
+  //  * This can be useful for `DurableStateBehavior` with change events, where the events are only used for the
+  //  * Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the
+  //  * offset timestamp of the Projections, if events are not needed after all Projections have processed them.
+  //  *
+  //  * Be aware of that if all events of a persistenceId are removed the sequence number will start from 1 again if an
+  //  * `EventSourcedBehavior` with the same persistenceId is used again.
+  //  *
+  //  * @param entityType
+  //  *   the entity type to delete for
+  //  * @param slice
+  //  *   the slice to delete for
+  //  * @param timestamp
+  //  *   timestamp (exclusive) to delete up to
+  //  */
+  // def deleteEventsBefore(entityType: String, slice: Int, timestamp: Instant): CompletionStage[Done] =
+  //   delegate.deleteEventsBefore(entityType, slice, timestamp).toJava
+
+  /**
+   * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   */
+  def deleteSnapshot(persistenceId: String): CompletionStage[Done] =
+    delegate.deleteSnapshot(persistenceId).toJava
+
+  /**
+   * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
+   */
+  def deleteSnapshots(persistenceIds: JList[String]): CompletionStage[Done] =
+    delegate.deleteSnapshots(persistenceIds.asScala.toVector).toJava
+
+  /**
+   * Deletes all events for the given persistence id from before the snapshot. The snapshot is not deleted. The event
+   * with the same sequence number as the remaining snapshot is deleted.
+   */
+  def cleanupBeforeSnapshot(persistenceId: String): CompletionStage[Done] =
+    delegate.cleanupBeforeSnapshot(persistenceId).toJava
+
+  /**
+   * See single persistenceId overload for what is done for each persistence id
+   */
+  def cleanupBeforeSnapshot(persistenceIds: JList[String]): CompletionStage[Done] =
+    delegate.cleanupBeforeSnapshot(persistenceIds.asScala.toVector).toJava
+
+  /**
+   * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAll(persistenceId, resetSequenceNumber).toJava
+
+  /**
+   * Delete everything related to the given list of `persistenceIds`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAll(persistenceIds.asScala.toVector, resetSequenceNumber).toJava
+
+}

--- a/core/src/main/scala/akka/persistence/dynamodb/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.dynamodb.cleanup.scaladsl
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+import akka.Done
+import akka.actor.ClassicActorSystemProvider
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
+import akka.persistence.SnapshotSelectionCriteria
+import akka.persistence.dynamodb.DynamoDBSettings
+import akka.persistence.dynamodb.internal.JournalDao
+import akka.persistence.dynamodb.internal.SnapshotDao
+import akka.persistence.dynamodb.util.ClientProvider
+import org.slf4j.LoggerFactory
+
+/**
+ * Scala API: Tool for deleting events and/or snapshots for a given list of `persistenceIds` without using persistent
+ * actors.
+ *
+ * When running an operation with `EventSourcedCleanup` that deletes all events for a persistence id, the actor with
+ * that persistence id must not be running! If the actor is restarted it would in that case be recovered to the wrong
+ * state since the stored events have been deleted. Delete events before snapshot can still be used while the actor is
+ * running.
+ *
+ * If `resetSequenceNumber` is `true` then an entity created with the same `persistenceId` will start from 0. Otherwise
+ * it will continue from the latest highest used sequence number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the sequence number should be avoided, since it might be
+ * confusing to reuse the same sequence number for new events.
+ *
+ * When a list of `persistenceIds` are given, they are deleted sequentially in the same order as the list. It's possible
+ * to parallelize the deletes by running several cleanup operations at the same time, each operating on different sets
+ * of `persistenceIds`.
+ */
+@ApiMayChange
+final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, configPath: String) {
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "akka.persistence.dynamodb.cleanup")
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] implicit val system: ActorSystem[_] = {
+    import akka.actor.typed.scaladsl.adapter._
+    systemProvider.classicSystem.toTyped
+  }
+
+  import system.executionContext
+
+  private val log = LoggerFactory.getLogger(classOf[EventSourcedCleanup])
+
+  private val sharedConfigPath = configPath.replaceAll("""\.cleanup$""", "")
+  private val settings = DynamoDBSettings(system.settings.config.getConfig(sharedConfigPath))
+
+  private val client = ClientProvider(system).clientFor(sharedConfigPath + ".client")
+  private val journalDao = new JournalDao(system, settings, client)
+  private val snapshotDao = new SnapshotDao(system, settings, client)
+
+  /**
+   * Delete all events before a sequenceNr for the given persistence id. Snapshots are not deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param toSequenceNr
+   *   sequence nr (inclusive) to delete up to
+   */
+  def deleteEventsTo(persistenceId: String, toSequenceNr: Long): Future[Done] = {
+    log.debug("deleteEventsTo persistenceId [{}], toSequenceNr [{}]", persistenceId, toSequenceNr)
+    journalDao.deleteEventsTo(persistenceId, toSequenceNr, resetSequenceNumber = false).map(_ => Done)
+  }
+
+  /**
+   * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): Future[Done] = {
+    journalDao
+      .deleteEventsTo(persistenceId, toSequenceNr = Long.MaxValue, resetSequenceNumber)
+      .map(_ => Done)
+  }
+
+  /**
+   * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceIds: immutable.Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
+    foreach(persistenceIds, "deleteAllEvents", pid => deleteAllEvents(pid, resetSequenceNumber))
+  }
+
+  // TODO: Delete before timestamp operations.
+  //       Will either be full scans across the event journal, or require some kind of specialised indexing
+  //       to get the highest sequence number before a timestamp, and then call deleteEventsTo with batching.
+  //
+  // /**
+  //  * Delete events before a timestamp for the given persistence id. Snapshots are not deleted.
+  //  *
+  //  * This can be useful for `DurableStateBehavior` with change events, where the events are only used for the
+  //  * Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the
+  //  * offset timestamp of the Projections, if events are not needed after all Projections have processed them.
+  //  *
+  //  * Be aware of that if all events of a persistenceId are removed the sequence number will start from 1 again if an
+  //  * `EventSourcedBehavior` with the same persistenceId is used again.
+  //  *
+  //  * @param persistenceId
+  //  *   the persistence id to delete for
+  //  * @param timestamp
+  //  *   timestamp (exclusive) to delete up to
+  //  */
+  // def deleteEventsBefore(persistenceId: String, timestamp: Instant): Future[Done] = {
+  //   log.debug("deleteEventsBefore persistenceId [{}], timestamp [{}]", persistenceId, timestamp)
+  //   journalDao.deleteEventsBefore(persistenceId, timestamp).map(_ => Done)
+  // }
+
+  // TODO: Delete before timestamp operations.
+  //       Will either be full scans across the event journal, or require some kind of specialised indexing
+  //       to find persistence ids and highest sequence numbers before a timestamp, then call deleteEventsTo.
+  //
+  // /**
+  //  * Delete events before a timestamp for the given entityType and slice. Snapshots are not deleted.
+  //  *
+  //  * This can be useful for `DurableStateBehavior` with change events, where the events are only used for the
+  //  * Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the
+  //  * offset timestamp of the Projections, if events are not needed after all Projections have processed them.
+  //  *
+  //  * Be aware of that if all events of a persistenceId are removed the sequence number will start from 1 again if an
+  //  * `EventSourcedBehavior` with the same persistenceId is used again.
+  //  *
+  //  * @param entityType
+  //  *   the entity type to delete for
+  //  * @param slice
+  //  *   the slice to delete for
+  //  * @param timestamp
+  //  *   timestamp (exclusive) to delete up to
+  //  */
+  // def deleteEventsBefore(entityType: String, slice: Int, timestamp: Instant): Future[Done] = {
+  //   log.debug("deleteEventsBefore [{}], slice [{}] timestamp [{}]", entityType, slice, timestamp)
+  //   journalDao.deleteEventsBefore(entityType, slice, timestamp).map(_ => Done)
+  // }
+
+  /**
+   * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   */
+  def deleteSnapshot(persistenceId: String): Future[Done] = {
+    snapshotDao
+      .delete(persistenceId, SnapshotSelectionCriteria(maxSequenceNr = Long.MaxValue))
+      .map(_ => Done)
+  }
+
+  /**
+   * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
+   */
+  def deleteSnapshots(persistenceIds: immutable.Seq[String]): Future[Done] = {
+    foreach(persistenceIds, "deleteSnapshots", pid => deleteSnapshot(pid))
+  }
+
+  /**
+   * Deletes all events for the given persistence id from before the snapshot. The snapshot is not deleted. The event
+   * with the same sequence number as the remaining snapshot is deleted.
+   */
+  def cleanupBeforeSnapshot(persistenceId: String): Future[Done] = {
+    snapshotDao.load(persistenceId, SnapshotSelectionCriteria.Latest).flatMap {
+      case None => Future.successful(Done)
+      case Some(snapshot) =>
+        deleteEventsTo(persistenceId, snapshot.seqNr)
+    }
+  }
+
+  /**
+   * See single persistenceId overload for what is done for each persistence id.
+   */
+  def cleanupBeforeSnapshot(persistenceIds: immutable.Seq[String]): Future[Done] = {
+    foreach(persistenceIds, "cleanupBeforeSnapshot", pid => cleanupBeforeSnapshot(pid))
+  }
+
+  /**
+   * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): Future[Done] = {
+    for {
+      _ <- deleteAllEvents(persistenceId, resetSequenceNumber)
+      _ <- deleteSnapshot(persistenceId)
+    } yield Done
+  }
+
+  /**
+   * Delete everything related to the given list of `persistenceIds`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceIds: immutable.Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
+    foreach(persistenceIds, "deleteAll", pid => deleteAll(pid, resetSequenceNumber))
+  }
+
+  private def foreach(
+      persistenceIds: immutable.Seq[String],
+      operationName: String,
+      pidOperation: String => Future[Done]): Future[Done] = {
+    val size = persistenceIds.size
+    log.info("Cleanup started {} of [{}] persistenceId.", operationName, size)
+
+    def loop(remaining: List[String], n: Int): Future[Done] = {
+      remaining match {
+        case Nil => Future.successful(Done)
+        case pid :: tail =>
+          pidOperation(pid).flatMap { _ =>
+            if (n % settings.cleanupSettings.logProgressEvery == 0)
+              log.infoN("Cleanup {} [{}] of [{}].", operationName, n, size)
+            loop(tail, n + 1)
+          }
+      }
+    }
+
+    val result = loop(persistenceIds.toList, n = 1)
+
+    result.onComplete {
+      case Success(_) =>
+        log.info2("Cleanup completed {} of [{}] persistenceId.", operationName, size)
+      case Failure(e) =>
+        log.error(s"Cleanup {$operationName} failed.", e)
+    }
+
+    result
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
@@ -1,0 +1,417 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.dynamodb.cleanup
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.dynamodb.TestActors.Persister
+import akka.persistence.dynamodb.TestConfig
+import akka.persistence.dynamodb.TestData
+import akka.persistence.dynamodb.TestDbLifecycle
+import akka.persistence.typed.PersistenceId
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.persistence.dynamodb.cleanup.scaladsl.EventSourcedCleanup
+import com.typesafe.config.Config
+import org.slf4j.event.Level
+
+object EventSourcedCleanupSpec {
+  val config: Config = ConfigFactory
+    .parseString(s"""
+    akka.loglevel = DEBUG
+    akka.persistence.dynamodb.cleanup {
+      log-progress-every = 2
+    }
+  """)
+    .withFallback(TestConfig.config)
+}
+
+class EventSourcedCleanupSpec
+    extends ScalaTestWithActorTestKit(EventSourcedCleanupSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+
+  "EventSourcedCleanup" must {
+    "delete all events for one persistenceId" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val seqNrProbe = createTestProbe[Long]()
+      val pid = nextPid()
+      val p = spawn(Persister(pid))
+
+      (1 to 10).foreach { n =>
+        p ! Persister.PersistWithAck(n, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.deleteAllEvents(pid, resetSequenceNumber = true).futureValue
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("")
+      p2 ! Persister.GetSeqNr(seqNrProbe.ref)
+      seqNrProbe.expectMessage(0L)
+    }
+
+    "delete all events for one persistenceId in batches" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val seqNrProbe = createTestProbe[Long]()
+      val pid = nextPid()
+      val p = spawn(Persister(pid))
+
+      val maxSeqNumber = 321
+      (1 to maxSeqNumber).foreach { n =>
+        p ! Persister.PersistWithAck(n, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+
+      var iteration = 0
+      val batchSize = 100 // hard-coded TransactWriteItems limit
+
+      LoggingTestKit
+        .info("Deleted")
+        .withLogLevel(Level.DEBUG)
+        .withOccurrences(4)
+        .withCustom { event =>
+          val from = (iteration * batchSize) + 1
+          iteration = iteration + 1
+          val to = Math.min(maxSeqNumber, from + batchSize - 1)
+          val deleted = to - from + 1
+          val expectedMsg = s"Deleted events from [$from] to [$to] for persistenceId [$pid], consumed [8.0] WCU"
+          event.message == expectedMsg
+        }
+        .expect {
+          cleanup.deleteAllEvents(pid, resetSequenceNumber = true).futureValue
+        }
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("")
+      p2 ! Persister.GetSeqNr(seqNrProbe.ref)
+      seqNrProbe.expectMessage(0L)
+    }
+
+    "delete all events for one persistenceId, but keep seqNr" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val seqNrProbe = createTestProbe[Long]()
+      val pid = nextPid()
+      val p = spawn(Persister(pid))
+
+      (1 to 10).foreach { n =>
+        p ! Persister.PersistWithAck(n, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.deleteAllEvents(pid, resetSequenceNumber = false).futureValue
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("")
+      p2 ! Persister.GetSeqNr(seqNrProbe.ref)
+      seqNrProbe.expectMessage(10L)
+    }
+
+    "delete all events for one persistenceId in batches, but keep seqNr" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val seqNrProbe = createTestProbe[Long]()
+      val pid = nextPid()
+      val p = spawn(Persister(pid))
+
+      val maxSeqNumber = 321
+      (1 to maxSeqNumber).foreach { n =>
+        p ! Persister.PersistWithAck(n, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+
+      var iteration = 0
+      val batchSize = 100 // hard-coded TransactWriteItems limit
+
+      LoggingTestKit
+        .info("Deleted")
+        .withLogLevel(Level.DEBUG)
+        .withOccurrences(4)
+        .withCustom { event =>
+          val from = (iteration * batchSize) + 1
+          iteration = iteration + 1
+          val to = Math.min(maxSeqNumber, from + batchSize - 1)
+          val deleted = to - from + 1
+          val expectedMsg = s"Deleted events from [$from] to [$to] for persistenceId [$pid], consumed [8.0] WCU"
+          event.message == expectedMsg
+        }
+        .expect {
+          cleanup.deleteAllEvents(pid, resetSequenceNumber = false).futureValue
+        }
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("")
+      p2 ! Persister.GetSeqNr(seqNrProbe.ref)
+      seqNrProbe.expectMessage(maxSeqNumber.toLong)
+    }
+
+    "delete some events for one persistenceId" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val seqNrProbe = createTestProbe[Long]()
+      val pid = nextPid()
+      val p = spawn(Persister(pid))
+
+      (1 to 8).foreach { n =>
+        p ! Persister.PersistWithAck(n, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.deleteEventsTo(pid, 5).futureValue
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("6|7|8")
+      p2 ! Persister.GetSeqNr(seqNrProbe.ref)
+      seqNrProbe.expectMessage(8L)
+    }
+
+    "delete snapshots for one persistenceId" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val pid = nextPid()
+      val p = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      (1 to 10).foreach { n =>
+        p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.deleteAllEvents(pid, resetSequenceNumber = false).futureValue
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("1|2|3-snap")
+      testKit.stop(p2)
+
+      cleanup.deleteSnapshot(pid).futureValue
+
+      val p3 = spawn(Persister(pid))
+      p3 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("")
+    }
+
+    "cleanup before snapshot" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val pid = nextPid()
+      val p = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      (1 to 10).foreach { n =>
+        p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(p)
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.cleanupBeforeSnapshot(pid).futureValue
+
+      val p2 = spawn(Persister(pid))
+      p2 ! Persister.GetState(stateProbe.ref)
+      stateProbe.expectMessage("1|2|3-snap|4|5|6|7|8|9|10")
+      testKit.stop(p2)
+
+      cleanup.deleteSnapshot(pid).futureValue
+
+      val p3 = spawn(Persister(pid))
+      p3 ! Persister.GetState(stateProbe.ref)
+      // from replaying remaining events
+      stateProbe.expectMessage("4|5|6|7|8|9|10")
+    }
+
+    "cleanup all before snapshot" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val pids = Vector(nextPid(), nextPid(), nextPid())
+      val persisters =
+        pids.map { pid =>
+          spawn(Behaviors.setup[Persister.Command] { context =>
+            Persister
+              .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+              .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+          })
+        }
+
+      (1 to 10).foreach { n =>
+        persisters.foreach { p =>
+          p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(testKit.stop(_))
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.cleanupBeforeSnapshot(pids).futureValue
+      cleanup.deleteSnapshots(pids).futureValue
+
+      val persisters2 = pids.map(pid => spawn(Persister(pid)))
+      persisters2.foreach { p =>
+        p ! Persister.GetState(stateProbe.ref)
+        // from replaying remaining events
+        stateProbe.expectMessage("4|5|6|7|8|9|10")
+      }
+    }
+
+    "delete all events and snapshots" in {
+      val ackProbe = createTestProbe[Done]()
+      val stateProbe = createTestProbe[String]()
+      val seqNrProbe = createTestProbe[Long]()
+      val pids = Vector(nextPid(), nextPid(), nextPid())
+      val persisters =
+        pids.map { pid =>
+          spawn(Behaviors.setup[Persister.Command] { context =>
+            Persister
+              .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+              .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+          })
+        }
+
+      (1 to 10).foreach { n =>
+        persisters.foreach { p =>
+          p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(testKit.stop(_))
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.deleteAll(pids, resetSequenceNumber = true).futureValue
+
+      val persisters2 = pids.map(pid => spawn(Persister(pid)))
+      persisters2.foreach { p =>
+        p ! Persister.GetState(stateProbe.ref)
+        stateProbe.expectMessage("")
+        p ! Persister.GetSeqNr(seqNrProbe.ref)
+        seqNrProbe.expectMessage(0L)
+      }
+    }
+
+    // TODO: Delete before timestamp operations.
+    //
+    // "delete events for one persistenceId before timestamp" in {
+    //   val ackProbe = createTestProbe[Done]()
+    //   val pid = nextPid()
+    //   val p = spawn(Persister(pid))
+    //
+    //   (1 to 10).foreach { n =>
+    //     p ! Persister.PersistWithAck(n, ackProbe.ref)
+    //     ackProbe.expectMessage(Done)
+    //     ackProbe.expectNoMessage(1.millis) // just to be sure that events have different timestamps
+    //   }
+    //
+    //   testKit.stop(p)
+    //
+    //   val journalQuery =
+    //     PersistenceQuery(system).readJournalFor[CurrentEventsByPersistenceIdTypedQuery](DynamoDBReadJournal.Identifier)
+    //   val eventsBefore =
+    //     journalQuery.currentEventsByPersistenceIdTyped[Any](pid, 1L, Long.MaxValue).runWith(Sink.seq).futureValue
+    //   eventsBefore.size shouldBe 10
+    //
+    //   val cleanup = new EventSourcedCleanup(system)
+    //   val timestamp = eventsBefore.last.offset.asInstanceOf[TimestampOffset].timestamp
+    //   cleanup.deleteEventsBefore(pid, timestamp).futureValue
+    //
+    //   val eventsAfter =
+    //     journalQuery.currentEventsByPersistenceIdTyped[Any](pid, 1L, Long.MaxValue).runWith(Sink.seq).futureValue
+    //   eventsAfter.size shouldBe 1
+    //   eventsAfter.head.sequenceNr shouldBe eventsBefore.last.sequenceNr
+    // }
+
+    // TODO: Delete before timestamp operations.
+    //
+    // "delete events for slice before timestamp" in {
+    //   val ackProbe = createTestProbe[Done]()
+    //   val entityType = nextEntityType()
+    //
+    //   var (pid1, pid2) = pidsWithSliceLessThan256(entityType)
+    //
+    //   val p1 = spawn(Persister(pid1))
+    //   val p2 = spawn(Persister(pid2))
+    //
+    //   (1 to 10).foreach { n =>
+    //     val p = if (n % 2 == 0) p2 else p1
+    //     p ! Persister.PersistWithAck(n, ackProbe.ref)
+    //     ackProbe.expectMessage(Done)
+    //     ackProbe.expectNoMessage(1.millis) // just to be sure that events have different timestamps
+    //   }
+    //
+    //   testKit.stop(p1)
+    //   testKit.stop(p2)
+    //
+    //   val journalQuery =
+    //     PersistenceQuery(system).readJournalFor[CurrentEventsBySliceQuery](DynamoDBReadJournal.Identifier)
+    //   val eventsBefore =
+    //     journalQuery
+    //       .currentEventsBySlices[Any](entityType, 0, 255, Offset.noOffset)
+    //       .runWith(Sink.seq)
+    //       .futureValue
+    //   eventsBefore.size shouldBe 10
+    //   eventsBefore.last.persistenceId shouldBe pid2.id
+    //
+    //   // we remove all except last for p2, and p1 should remain untouched
+    //   val cleanup = new EventSourcedCleanup(system)
+    //   val timestamp = eventsBefore.last.offset.asInstanceOf[TimestampOffset].timestamp
+    //   val slice = persistenceExt.sliceForPersistenceId(eventsBefore.last.persistenceId)
+    //   cleanup.deleteEventsBefore(entityType, slice, timestamp).futureValue
+    //
+    //   val eventsAfter =
+    //     journalQuery
+    //       .currentEventsBySlices[Any](entityType, 0, 255, Offset.noOffset)
+    //       .runWith(Sink.seq)
+    //       .futureValue
+    //   eventsAfter.count(_.persistenceId == pid1.id) shouldBe 5
+    //   eventsAfter.count(_.persistenceId == pid2.id) shouldBe 1
+    //   eventsAfter.size shouldBe 5 + 1
+    //   eventsAfter.filter(_.persistenceId == pid2.id).last.sequenceNr shouldBe eventsBefore.last.sequenceNr
+    // }
+
+  }
+}

--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -8,8 +8,8 @@ snapshot](./query.md#eventsbyslicesstartingfromsnapshots), and then events can b
 
 In some cases keeping all events is not possible, or data must be removed for regulatory reasons, such as compliance
 with GDPR. `EventSourcedBehavior`s can also automatically
-@extref:[delete events](akka:typed/persistence-snapshot.html#event-deletion). Snapshotting is useful even if events
-aren't deleted as it speeds up recovery.
+@extref:[delete events on snapshot](akka:typed/persistence-snapshot.html#event-deletion). Snapshotting is useful even
+if events aren't deleted as it speeds up recovery.
 
 Deleting all events immediately when an entity has reached its terminal deleted state would have the consequence that
 Projections may not have consumed all previous events yet and will not be notified of the deleted event. Instead, it's
@@ -36,3 +36,9 @@ stored events have been deleted. Deleting events before snapshot can still be us
 
 <!-- TODO: current persistence ids queries not currently supported. -->
 <!-- The cleanup tool can be combined with the @ref[query plugin](./query.md) which has a query to get all persistence ids. -->
+
+## Reference configuration
+
+The following can be overridden in your `application.conf` for cleanup specific settings:
+
+@@snip [reference.conf](/core/src/main/resources/reference.conf) { #cleanup-settings }

--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -1,0 +1,38 @@
+# Database cleanup
+
+## Event Sourced cleanup tool
+
+If possible, it is best to keep all events in an event sourced system. That way new @ref:[Projections](projection.md)
+can be re-built. A @ref[Projection can also start or continue from a
+snapshot](./query.md#eventsbyslicesstartingfromsnapshots), and then events can be deleted before the snapshot.
+
+In some cases keeping all events is not possible, or data must be removed for regulatory reasons, such as compliance
+with GDPR. `EventSourcedBehavior`s can also automatically
+@extref:[delete events](akka:typed/persistence-snapshot.html#event-deletion). Snapshotting is useful even if events
+aren't deleted as it speeds up recovery.
+
+Deleting all events immediately when an entity has reached its terminal deleted state would have the consequence that
+Projections may not have consumed all previous events yet and will not be notified of the deleted event. Instead, it's
+recommended to emit a final deleted event and store the fact that the entity is deleted separately via a Projection.
+Then a background task can clean up the events and snapshots for the deleted entities by using the
+@apidoc[EventSourcedCleanup] tool. The entity itself knows about the terminal state from the deleted event and should
+not emit further events after that, and typically stop itself if it receives any further commands.
+
+@apidoc[EventSourcedCleanup] operations include:
+
+* Delete all events and snapshots for one or many persistence ids
+* Delete all events for one or many persistence ids
+* Delete all snapshots for one or many persistence ids
+* Delete events before snapshot for one or many persistence ids
+<!-- TODO: * Delete events before a timestamp -->
+
+@@@ warning
+
+When running an operation with `EventSourcedCleanup` that deletes all events for a persistence id, the actor with that
+persistence id must not be running! If the actor is restarted, it would be recovered to the wrong state, since the
+stored events have been deleted. Deleting events before snapshot can still be used while the actor is running.
+
+@@@
+
+<!-- TODO: current persistence ids queries not currently supported. -->
+<!-- The cleanup tool can be combined with the @ref[query plugin](./query.md) which has a query to get all persistence ids. -->

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -13,6 +13,7 @@ This Akka Persistence plugin allows for using Amazon DynamoDB as a backend for A
 * [Query Plugin](query.md)
 * [Projection](projection.md)
 * [Configuration](config.md)
+* [Database cleanup](cleanup.md)
 * [Contributing](contributing.md)
 
 @@@


### PR DESCRIPTION
Refs #26. Core operations for event sourced entity cleanup. Doesn't support the before timestamp operations — we would ideally need some way to get persistent ids for a slice, and highest sequence number before a timestamp, and then use the (batched) delete up to sequence number operation. We also don't have current persistent id queries in general.