### PR TITLE
docs: add deletes section for journal docs

### DIFF
--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -4,7 +4,7 @@
 
 If possible, it is best to keep all events in an event sourced system. That way new @ref:[Projections](projection.md)
 can be re-built. A @ref[Projection can also start or continue from a
-snapshot](./query.md#eventsbyslicesstartingfromsnapshots), and then events can be deleted before the snapshot.
+snapshot](query.md#eventsbyslicesstartingfromsnapshots), and then events can be deleted before the snapshot.
 
 In some cases keeping all events is not possible, or data must be removed for regulatory reasons, such as compliance
 with GDPR. `EventSourcedBehavior`s can also automatically

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -60,4 +60,16 @@ The events are serialized with @extref:[Akka Serialization](akka:serialization.h
 is stored in the `event_payload` column together with information about what serializer that was used in the
 `event_ser_id` and `event_ser_manifest` columns.
 
-<!-- TODO: ## Deletes -->
+## Deletes
+
+The journal supports deletes through hard deletes, which means that journal entries are actually deleted from the
+database. There is no materialized view with a copy of the event, so make sure to not delete events too early if they
+are used from projections or queries. A projection can also @ref:[start or continue from a
+snapshot](query.md#eventsbyslicesstartingfromsnapshots), and then events can be deleted before the snapshot.
+
+For each persistent id, a tombstone record is kept in the event journal when all events of a persistence id have been
+deleted. The reason for the tombstone record is to keep track of the latest sequence number so that subsequent events
+don't reuse the same sequence numbers that have been deleted.
+
+See the @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) for more information about how to delete
+events, snapshots, and tombstone records.


### PR DESCRIPTION
Pending todo in the docs. Can now link to start-from-snapshot queries and the cleanup tool.