### PR TITLE
docs: clarify indexing with separate example commands

### DIFF
--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -17,6 +17,12 @@ table should be created with the following attributes and key schema:
 Read capacity units should be based on expected entity recoveries. Write capacity units should be based on expected
 rates for persisting events.
 
+An example `aws` CLI command for creating the event journal table:
+
+@@snip [aws create event journal table](/scripts/create-tables.sh) { #create-event-journal-table }
+
+### Indexes
+
 If @ref:[queries](query.md) or @ref:[projections](projection.md) are being used, then a global secondary index needs to
 be added to the event journal table, to index events by slice. The default name for the secondary index is
 `event_journal_slice_idx`. The following attribute definitions should be added to the event journal table, with key
@@ -32,7 +38,9 @@ expected queries.
 
 An example `aws` CLI command for creating the event journal table and slice index:
 
-@@snip [aws create event journal table](/scripts/create-tables.sh) { #create-event-journal-table }
+@@snip [aws create event journal table](/scripts/create-tables.sh) { #create-event-journal-table-with-slice-index }
+
+### Creating tables locally
 
 For creating tables with DynamoDB local for testing, see the
 @ref:[CreateTables utility](getting-started.md#creating-tables-locally).

--- a/docs/src/main/paradox/query.md
+++ b/docs/src/main/paradox/query.md
@@ -73,6 +73,13 @@ timestamp are ordered by sequence number.
 `currentEventsBySlices` doesn't perform backtracking queries, will not emit duplicates, and the event payload is always
 fully loaded.
 
+@@@ note
+
+The @ref:[journal table](journal.md#tables) must be created with a global secondary index to @ref:[index events
+by slice](journal.md#indexes).
+
+@@@
+
 ### eventsBySlicesStartingFromSnapshots
 
 The `eventsBySlicesStartingFromSnapshots` and `currentEventsBySlicesStartingFromSnapshots` queries are like the
@@ -90,8 +97,12 @@ To use the start-from-snapshot queries you must also enable configuration:
 akka.persistence.dynamodb.query.start-from-snapshot.enabled = true
 ```
 
-The @ref:[snapshot table](snapshots.md#tables) must be created with a global secondary index, to index snapshots by
-slice.
+@@@ note
+
+The @ref:[snapshot table](snapshots.md#tables) must be created with a global secondary index to @ref:[index snapshots
+by slice](snapshots.md#indexes).
+
+@@@
 
 ### Publish events for lower latency of eventsBySlices
 

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -16,6 +16,12 @@ be created with the following attributes and key schema:
 Read capacity units should be based on expected entity recoveries. Write capacity units should be based on expected
 rates for persisting snapshots.
 
+An example `aws` CLI command for creating the snapshot table:
+
+@@snip [aws create snapshot table](/scripts/create-tables.sh) { #create-snapshot-table }
+
+### Indexes
+
 If @ref:[start-from-snapshot queries](query.md#eventsbyslicesstartingfromsnapshots) are being used, then a global
 secondary index needs to be added to the snapshot table, to index snapshots by slice. The default name for the
 secondary index is `snapshot_slice_idx`. The following attribute definitions should be added to the snapshot table,
@@ -31,7 +37,9 @@ expected queries.
 
 An example `aws` CLI command for creating the snapshot table and slice index:
 
-@@snip [aws create snapshot table](/scripts/create-tables.sh) { #create-snapshot-table }
+@@snip [aws create snapshot table](/scripts/create-tables.sh) { #create-snapshot-table-with-slice-index }
+
+### Creating tables locally
 
 For creating tables with DynamoDB local for testing, see the
 @ref:[CreateTables utility](getting-started.md#creating-tables-locally).

--- a/scripts/create-tables.sh
+++ b/scripts/create-tables.sh
@@ -1,7 +1,37 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-#create-event-journal-table
-aws dynamodb create-table \
+function fail {
+  echo "$@"
+  exit 1
+}
+
+declare no_journal_index=false
+declare no_snapshot_index=false
+
+while [[ $# -gt 0 ]] ; do
+  case "$1" in
+    --no-journal-index  ) no_journal_index=true  ; shift ;;
+    --no-snapshot-index ) no_snapshot_index=true ; shift ;;
+    *                   ) fail "unknown option: $1"    ;
+  esac
+done
+
+if $no_journal_index ; then
+  #create-event-journal-table
+  aws dynamodb create-table \
+    --table-name event_journal \
+    --attribute-definitions \
+        AttributeName=pid,AttributeType=S \
+        AttributeName=seq_nr,AttributeType=N \
+    --key-schema \
+        AttributeName=pid,KeyType=HASH \
+        AttributeName=seq_nr,KeyType=RANGE \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5 \
+  #create-event-journal-table
+else
+  #create-event-journal-table-with-slice-index
+  aws dynamodb create-table \
     --table-name event_journal \
     --attribute-definitions \
         AttributeName=pid,AttributeType=S \
@@ -30,10 +60,23 @@ aws dynamodb create-table \
            }
         }
       ]'
-#create-event-journal-table
+  #create-event-journal-table-with-slice-index
+fi
 
-#create-snapshot-table
-aws dynamodb create-table \
+if $no_snapshot_index ; then
+  #create-snapshot-table
+  aws dynamodb create-table \
+    --table-name snapshot \
+    --attribute-definitions \
+        AttributeName=pid,AttributeType=S \
+    --key-schema \
+        AttributeName=pid,KeyType=HASH \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5
+  #create-snapshot-table
+else
+  #create-snapshot-table-with-slice-index
+  aws dynamodb create-table \
     --table-name snapshot \
     --attribute-definitions \
         AttributeName=pid,AttributeType=S \
@@ -42,7 +85,7 @@ aws dynamodb create-table \
     --key-schema \
         AttributeName=pid,KeyType=HASH \
     --provisioned-throughput \
-        ReadCapacityUnits=5,WriteCapacityUnits=5
+        ReadCapacityUnits=5,WriteCapacityUnits=5 \
     --global-secondary-indexes \
       '[
          {
@@ -60,26 +103,27 @@ aws dynamodb create-table \
            }
         }
       ]'
-#create-snapshot-table
+  #create-snapshot-table-with-slice-index
+fi
 
 #create-timestamp-offset-table
 aws dynamodb create-table \
-    --table-name timestamp_offset \
-    --attribute-definitions \
-        AttributeName=name_slice,AttributeType=S \
-        AttributeName=pid,AttributeType=S \
-    --key-schema \
-        AttributeName=name_slice,KeyType=HASH \
-        AttributeName=pid,KeyType=RANGE \
-    --provisioned-throughput \
-        ReadCapacityUnits=5,WriteCapacityUnits=5
+  --table-name timestamp_offset \
+  --attribute-definitions \
+      AttributeName=name_slice,AttributeType=S \
+      AttributeName=pid,AttributeType=S \
+  --key-schema \
+      AttributeName=name_slice,KeyType=HASH \
+      AttributeName=pid,KeyType=RANGE \
+  --provisioned-throughput \
+      ReadCapacityUnits=5,WriteCapacityUnits=5
 #create-timestamp-offset-table
 
 aws dynamodb create-table \
-    --table-name projection_spec \
-    --attribute-definitions \
-        AttributeName=id,AttributeType=S \
-    --key-schema \
-        AttributeName=id,KeyType=HASH \
-    --provisioned-throughput \
-        ReadCapacityUnits=5,WriteCapacityUnits=5
+  --table-name projection_spec \
+  --attribute-definitions \
+      AttributeName=id,AttributeType=S \
+  --key-schema \
+      AttributeName=id,KeyType=HASH \
+  --provisioned-throughput \
+      ReadCapacityUnits=5,WriteCapacityUnits=5


### PR DESCRIPTION
Clarify the indexing requirements further. Have separate example commands, for creating the table only or creating with the slice index. Add notes with links under queries.