### PR TITLE
feat: make CreateTables utilities more configurable

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/util/TableSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/util/TableSettings.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.dynamodb.util
+
+object TableSettings {
+
+  /**
+   * Default table settings for running with DynamoDB local.
+   */
+  val Local = new TableSettings(throughput = ThroughputSettings.Local)
+
+  /**
+   * Scala API: Create table settings for CreateTables utilities.
+   *
+   * @param throughput
+   *   throughput settings for the table
+   * @return
+   *   table settings
+   */
+  def apply(throughput: ThroughputSettings): TableSettings =
+    new TableSettings(throughput)
+
+  /**
+   * Java API: Create table settings for CreateTables utilities.
+   *
+   * @param throughput
+   *   throughput settings for the table
+   * @return
+   *   table settings
+   */
+  def create(throughput: ThroughputSettings): TableSettings =
+    new TableSettings(throughput)
+}
+
+/**
+ * Table settings for CreateTables utilities.
+ *
+ * @param throughput
+ *   throughput settings for the table
+ */
+final class TableSettings(val throughput: ThroughputSettings)
+
+object IndexSettings {
+
+  /**
+   * Default index settings for running with DynamoDB local.
+   */
+  val Local = new IndexSettings(enabled = true, throughput = ThroughputSettings.Local)
+
+  /**
+   * Disabled index settings.
+   */
+  val Disabled = new IndexSettings(enabled = false, throughput = ThroughputSettings.Local)
+
+  /**
+   * Scala API: Create index settings for CreateTables utilities.
+   *
+   * @param throughput
+   *   throughput settings for the index
+   * @return
+   *   index settings for an enabled index
+   */
+  def apply(throughput: ThroughputSettings): IndexSettings =
+    new IndexSettings(enabled = true, throughput)
+
+  /**
+   * Java API: Create index settings for CreateTables utilities.
+   *
+   * @param throughput
+   *   throughput settings for the index
+   * @return
+   *   index settings for an enabled index
+   */
+  def create(throughput: ThroughputSettings): IndexSettings =
+    new IndexSettings(enabled = true, throughput)
+}
+
+/**
+ * Index settings for CreateTables utilities.
+ *
+ * @param enabled
+ *   whether the index is enabled
+ * @param throughput
+ *   throughput settings for the index
+ */
+final class IndexSettings(val enabled: Boolean, val throughput: ThroughputSettings)
+
+object ThroughputSettings {
+
+  /**
+   * Default throughput settings for running with DynamoDB local.
+   */
+  val Local: ThroughputSettings = provisioned(readCapacityUnits = 5L, writeCapacityUnits = 5L)
+
+  /**
+   * Create provisioned throughput settings.
+   *
+   * @param readCapacityUnits
+   *   the maximum number of strongly consistent reads consumed per second
+   * @param writeCapacityUnits
+   *   the maximum number of writes consumed per second
+   * @return
+   *   provisioned throughput settings
+   */
+  def provisioned(readCapacityUnits: Long, writeCapacityUnits: Long): ThroughputSettings =
+    new ProvisionedThroughputSettings(readCapacityUnits, writeCapacityUnits)
+
+  /**
+   * Create on-demand throughput settings.
+   *
+   * @param maxReadRequestUnits
+   *   the maximum number of read request units (for no maximum, set to -1)
+   * @param maxWriteRequestUnits
+   *   the maximum number of write request units (for no maximum, set to -1)
+   * @return
+   *   on-demand throughput settings
+   */
+  def onDemand(maxReadRequestUnits: Long, maxWriteRequestUnits: Long): ThroughputSettings =
+    new OnDemandThroughputSettings(maxReadRequestUnits, maxWriteRequestUnits)
+}
+
+sealed trait ThroughputSettings
+
+/**
+ * Provisioned throughput settings.
+ *
+ * @param readCapacityUnits
+ *   the maximum number of strongly consistent reads consumed per second
+ * @param writeCapacityUnits
+ *   the maximum number of writes consumed per second
+ */
+final class ProvisionedThroughputSettings(val readCapacityUnits: Long, val writeCapacityUnits: Long)
+    extends ThroughputSettings
+
+/**
+ * On-demand throughput settings.
+ *
+ * @param maxReadRequestUnits
+ *   the maximum number of read request units (for no maximum, set to -1)
+ * @param maxWriteRequestUnits
+ *   the maximum number of write request units (for no maximum, set to -1)
+ */
+final class OnDemandThroughputSettings(val maxReadRequestUnits: Long, val maxWriteRequestUnits: Long)
+    extends ThroughputSettings

--- a/core/src/main/scala/akka/persistence/dynamodb/util/javadsl/CreateTables.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/util/javadsl/CreateTables.scala
@@ -11,6 +11,8 @@ import scala.jdk.FutureConverters._
 import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.persistence.dynamodb.DynamoDBSettings
+import akka.persistence.dynamodb.util.IndexSettings
+import akka.persistence.dynamodb.util.TableSettings
 import akka.persistence.dynamodb.util.scaladsl
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
@@ -20,12 +22,34 @@ object CreateTables {
       settings: DynamoDBSettings,
       client: DynamoDbAsyncClient,
       deleteIfExists: Boolean): CompletionStage[Done] =
-    scaladsl.CreateTables.createJournalTable(system, settings, client, deleteIfExists).asJava
+    createJournalTable(system, settings, client, deleteIfExists, TableSettings.Local, IndexSettings.Local)
+
+  def createJournalTable(
+      system: ActorSystem[_],
+      settings: DynamoDBSettings,
+      client: DynamoDbAsyncClient,
+      deleteIfExists: Boolean,
+      tableSettings: TableSettings,
+      sliceIndexSettings: IndexSettings): CompletionStage[Done] =
+    scaladsl.CreateTables
+      .createJournalTable(system, settings, client, deleteIfExists, tableSettings, sliceIndexSettings)
+      .asJava
 
   def createSnapshotsTable(
       system: ActorSystem[_],
       settings: DynamoDBSettings,
       client: DynamoDbAsyncClient,
       deleteIfExists: Boolean): CompletionStage[Done] =
-    scaladsl.CreateTables.createSnapshotsTable(system, settings, client, deleteIfExists).asJava
+    createSnapshotsTable(system, settings, client, deleteIfExists, TableSettings.Local, IndexSettings.Local)
+
+  def createSnapshotsTable(
+      system: ActorSystem[_],
+      settings: DynamoDBSettings,
+      client: DynamoDbAsyncClient,
+      deleteIfExists: Boolean,
+      tableSettings: TableSettings,
+      sliceIndexSettings: IndexSettings): CompletionStage[Done] =
+    scaladsl.CreateTables
+      .createSnapshotsTable(system, settings, client, deleteIfExists, tableSettings, sliceIndexSettings)
+      .asJava
 }

--- a/projection/src/main/scala/akka/projection/dynamodb/javadsl/CreateTables.scala
+++ b/projection/src/main/scala/akka/projection/dynamodb/javadsl/CreateTables.scala
@@ -10,6 +10,7 @@ import scala.jdk.FutureConverters._
 
 import akka.Done
 import akka.actor.typed.ActorSystem
+import akka.persistence.dynamodb.util.TableSettings
 import akka.projection.dynamodb.DynamoDBProjectionSettings
 import akka.projection.dynamodb.scaladsl
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
@@ -20,6 +21,15 @@ object CreateTables {
       settings: DynamoDBProjectionSettings,
       client: DynamoDbAsyncClient,
       deleteIfExists: Boolean): CompletionStage[Done] =
-    scaladsl.CreateTables.createTimestampOffsetStoreTable(system, settings, client, deleteIfExists).asJava
+    createTimestampOffsetStoreTable(system, settings, client, deleteIfExists, TableSettings.Local)
 
+  def createTimestampOffsetStoreTable(
+      system: ActorSystem[_],
+      settings: DynamoDBProjectionSettings,
+      client: DynamoDbAsyncClient,
+      deleteIfExists: Boolean,
+      tableSettings: TableSettings): CompletionStage[Done] =
+    scaladsl.CreateTables
+      .createTimestampOffsetStoreTable(system, settings, client, deleteIfExists, tableSettings)
+      .asJava
 }


### PR DESCRIPTION
Refs #28. Allow some configurability for CreateTables — throughput settings and whether to create the associated indexes. Still only documented for using for local testing, but makes it more possible to use against DynamoDB itself.