### PR TITLE
feat: add expiry (time to live) to event sourced cleanup tool

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/cleanup/javadsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/cleanup/javadsl/EventSourcedCleanup.scala
@@ -4,11 +4,14 @@
 
 package akka.persistence.dynamodb.cleanup.javadsl
 
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.CompletionStage
 import java.util.{ List => JList }
 
-import scala.compat.java8.FutureConverters._
 import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+import scala.jdk.FutureConverters._
 
 import akka.Done
 import akka.actor.ClassicActorSystemProvider
@@ -16,8 +19,8 @@ import akka.annotation.ApiMayChange
 import akka.persistence.dynamodb.cleanup.scaladsl
 
 /**
- * Java API: Tool for deleting events and/or snapshots for a given list of `persistenceIds` without using persistent
- * actors.
+ * Java API: Tool for deleting or setting expiration (time to live) of events and/or snapshots for a given list of
+ * `persistenceIds` without using persistent actors.
  *
  * When running an operation with `EventSourcedCleanup` that deletes all events for a persistence id, the actor with
  * that persistence id must not be running! If the actor is restarted it would in that case be recovered to the wrong
@@ -52,19 +55,29 @@ final class EventSourcedCleanup private (delegate: scaladsl.EventSourcedCleanup)
    *   sequence nr (inclusive) to delete up to
    */
   def deleteEventsTo(persistenceId: String, toSequenceNr: Long): CompletionStage[Done] =
-    delegate.deleteEventsTo(persistenceId, toSequenceNr).toJava
+    delegate.deleteEventsTo(persistenceId, toSequenceNr).asJava
 
   /**
    * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
    */
   def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
-    delegate.deleteAllEvents(persistenceId, resetSequenceNumber).toJava
+    delegate.deleteAllEvents(persistenceId, resetSequenceNumber).asJava
 
   /**
    * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
+   * @param resetSequenceNumber
+   *   whether the entities will start from zero again, or continue from highest sequence number
    */
   def deleteAllEvents(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
-    delegate.deleteAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber).toJava
+    delegate.deleteAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber).asJava
 
   // TODO: Delete before timestamp operations.
   //
@@ -84,7 +97,7 @@ final class EventSourcedCleanup private (delegate: scaladsl.EventSourcedCleanup)
   //  *   timestamp (exclusive) to delete up to
   //  */
   // def deleteEventsBefore(persistenceId: String, timestamp: Instant): CompletionStage[Done] =
-  //   delegate.deleteEventsBefore(persistenceId, timestamp).toJava
+  //   delegate.deleteEventsBefore(persistenceId, timestamp).asJava
 
   // TODO: Delete before timestamp operations.
   //
@@ -106,43 +119,333 @@ final class EventSourcedCleanup private (delegate: scaladsl.EventSourcedCleanup)
   //  *   timestamp (exclusive) to delete up to
   //  */
   // def deleteEventsBefore(entityType: String, slice: Int, timestamp: Instant): CompletionStage[Done] =
-  //   delegate.deleteEventsBefore(entityType, slice, timestamp).toJava
+  //   delegate.deleteEventsBefore(entityType, slice, timestamp).asJava
 
   /**
    * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
    */
   def deleteSnapshot(persistenceId: String): CompletionStage[Done] =
-    delegate.deleteSnapshot(persistenceId).toJava
+    delegate.deleteSnapshot(persistenceId).asJava
 
   /**
    * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
    */
   def deleteSnapshots(persistenceIds: JList[String]): CompletionStage[Done] =
-    delegate.deleteSnapshots(persistenceIds.asScala.toVector).toJava
+    delegate.deleteSnapshots(persistenceIds.asScala.toVector).asJava
 
   /**
    * Deletes all events for the given persistence id from before the snapshot. The snapshot is not deleted. The event
    * with the same sequence number as the remaining snapshot is deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
    */
   def cleanupBeforeSnapshot(persistenceId: String): CompletionStage[Done] =
-    delegate.cleanupBeforeSnapshot(persistenceId).toJava
+    delegate.cleanupBeforeSnapshot(persistenceId).asJava
 
   /**
-   * See single persistenceId overload for what is done for each persistence id
+   * See single persistenceId overload for what is done for each persistence id.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
    */
   def cleanupBeforeSnapshot(persistenceIds: JList[String]): CompletionStage[Done] =
-    delegate.cleanupBeforeSnapshot(persistenceIds.asScala.toVector).toJava
+    delegate.cleanupBeforeSnapshot(persistenceIds.asScala.toVector).asJava
 
   /**
    * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
    */
   def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
-    delegate.deleteAll(persistenceId, resetSequenceNumber).toJava
+    delegate.deleteAll(persistenceId, resetSequenceNumber).asJava
 
   /**
    * Delete everything related to the given list of `persistenceIds`. All events and snapshots are deleted.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
    */
   def deleteAll(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
-    delegate.deleteAll(persistenceIds.asScala.toVector, resetSequenceNumber).toJava
+    delegate.deleteAll(persistenceIds.asScala.toVector, resetSequenceNumber).asJava
+
+  /**
+   * Set expiry (time to live) for all events up to a sequence number for the given persistence id. Snapshots do not
+   * have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param toSequenceNr
+   *   sequence number (inclusive) to set expiry
+   * @param expiryTimestamp
+   *   expiration timestamp to set on selected events
+   */
+  def setExpiryForEvents(persistenceId: String, toSequenceNr: Long, expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate.setExpiryForEvents(persistenceId, toSequenceNr, expiryTimestamp).asJava
+
+  /**
+   * Set expiry (time to live) for all events up to a sequence number for the given persistence id. Snapshots do not
+   * have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param toSequenceNr
+   *   sequence number (inclusive) to set expiry
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForEvents(persistenceId: String, toSequenceNr: Long, timeToLive: Duration): CompletionStage[Done] =
+    delegate.setExpiryForEvents(persistenceId, toSequenceNr, timeToLive.toScala).asJava
+
+  /**
+   * Set expiry (time to live) for all events related to a single persistence id. Snapshots do not have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all events
+   */
+  def setExpiryForAllEvents(
+      persistenceId: String,
+      resetSequenceNumber: Boolean,
+      expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate.setExpiryForAllEvents(persistenceId, resetSequenceNumber, expiryTimestamp).asJava
+
+  /**
+   * Set expiry (time to live) for all events related to a single persistence id. Snapshots do not have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForAllEvents(
+      persistenceId: String,
+      resetSequenceNumber: Boolean,
+      timeToLive: Duration): CompletionStage[Done] =
+    delegate.setExpiryForAllEvents(persistenceId, resetSequenceNumber, timeToLive.toScala).asJava
+
+  /**
+   * Set expiry (time to live) for all events related to the given list of `persistenceIds`. Snapshots do not have
+   * expiry set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
+   * @param resetSequenceNumber
+   *   whether the entities will start from zero again, or continue from highest sequence number
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all events
+   */
+  def setExpiryForAllEvents(
+      persistenceIds: JList[String],
+      resetSequenceNumber: Boolean,
+      expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate
+      .setExpiryForAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber, expiryTimestamp)
+      .asJava
+
+  /**
+   * Set expiry (time to live) for all events related to the given list of `persistenceIds`. Snapshots do not have
+   * expiry set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
+   * @param resetSequenceNumber
+   *   whether the entities will start from zero again, or continue from highest sequence number
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForAllEvents(
+      persistenceIds: JList[String],
+      resetSequenceNumber: Boolean,
+      timeToLive: Duration): CompletionStage[Done] =
+    delegate
+      .setExpiryForAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber, timeToLive.toScala)
+      .asJava
+
+  /**
+   * Set expiry (time to live) for the snapshot related to a single persistence id. Events do not have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param expiryTimestamp
+   *   expiration timestamp to set on the snapshot
+   */
+  def setExpiryForSnapshot(persistenceId: String, expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate.setExpiryForSnapshot(persistenceId, expiryTimestamp).asJava
+
+  /**
+   * Set expiry (time to live) for the snapshot related to a single persistence id. Events do not have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForSnapshot(persistenceId: String, timeToLive: Duration): CompletionStage[Done] =
+    delegate.setExpiryForSnapshot(persistenceId, timeToLive.toScala).asJava
+
+  /**
+   * Set expiry (time to live) for all snapshots related to the given list of persistence ids. Events do not have expiry
+   * set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to set expiry for
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all snapshots
+   */
+  def setExpiryForSnapshots(persistenceIds: JList[String], expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate.setExpiryForSnapshots(persistenceIds.asScala.toVector, expiryTimestamp).asJava
+
+  /**
+   * Set expiry (time to live) for all snapshots related to the given list of persistence ids. Events do not have expiry
+   * set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to set expiry for
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForSnapshots(persistenceIds: JList[String], timeToLive: Duration): CompletionStage[Done] =
+    delegate.setExpiryForSnapshots(persistenceIds.asScala.toVector, timeToLive.toScala).asJava
+
+  /**
+   * Set expiry (time to live) for all events for the given persistence id from before its snapshot. The snapshot does
+   * not have expiry set. The event with the same sequence number as the snapshot does have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all events before snapshot
+   */
+  def setExpiryForEventsBeforeSnapshot(persistenceId: String, expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate.setExpiryForEventsBeforeSnapshot(persistenceId, expiryTimestamp).asJava
+
+  /**
+   * Set expiry (time to live) for all events for the given persistence id from before its snapshot. The snapshot does
+   * not have expiry set. The event with the same sequence number as the snapshot does have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to set expiry for
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForEventsBeforeSnapshot(persistenceId: String, timeToLive: Duration): CompletionStage[Done] =
+    delegate.setExpiryForEventsBeforeSnapshot(persistenceId, timeToLive.toScala).asJava
+
+  /**
+   * Set expiry (time to live) for all events for the given persistence ids from before their snapshots. The snapshots
+   * do not have expiry set. The events with the same sequence number as the snapshots do have expiry set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to set expiry for
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all events before snapshot
+   */
+  def setExpiryForEventsBeforeSnapshots(
+      persistenceIds: JList[String],
+      expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate.setExpiryForEventsBeforeSnapshots(persistenceIds.asScala.toVector, expiryTimestamp).asJava
+
+  /**
+   * Set expiry (time to live) for all events for the given persistence ids from before their snapshots. The snapshots
+   * do not have expiry set. The events with the same sequence number as the snapshots do have expiry set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to set expiry for
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForEventsBeforeSnapshots(persistenceIds: JList[String], timeToLive: Duration): CompletionStage[Done] =
+    delegate
+      .setExpiryForEventsBeforeSnapshots(persistenceIds.asScala.toVector, timeToLive.toScala)
+      .asJava
+
+  /**
+   * Set expiry for everything related to a single persistence id. All events and the snapshot have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all events before snapshot
+   */
+  def setExpiryForAllEventsAndSnapshot(
+      persistenceId: String,
+      resetSequenceNumber: Boolean,
+      expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate
+      .setExpiryForAllEventsAndSnapshot(persistenceId, resetSequenceNumber, expiryTimestamp)
+      .asJava
+
+  /**
+   * Set expiry for everything related to a single persistence id. All events and the snapshot have expiry set.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForAllEventsAndSnapshot(
+      persistenceId: String,
+      resetSequenceNumber: Boolean,
+      timeToLive: Duration): CompletionStage[Done] =
+    delegate
+      .setExpiryForAllEventsAndSnapshot(persistenceId, resetSequenceNumber, timeToLive.toScala)
+      .asJava
+
+  /**
+   * Set expiry for everything related to the given persistence ids. All events and snapshots have expiry set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
+   * @param expiryTimestamp
+   *   expiration timestamp to set on all events before snapshot
+   */
+  def setExpiryForAllEventsAndSnapshots(
+      persistenceIds: JList[String],
+      resetSequenceNumber: Boolean,
+      expiryTimestamp: Instant): CompletionStage[Done] =
+    delegate
+      .setExpiryForAllEventsAndSnapshots(persistenceIds.asScala.toVector, resetSequenceNumber, expiryTimestamp)
+      .asJava
+
+  /**
+   * Set expiry for everything related to the given persistence ids. All events and snapshots have expiry set.
+   *
+   * @param persistenceIds
+   *   the persistence ids to delete for
+   * @param resetSequenceNumber
+   *   whether the entity will start from zero again, or continue from highest sequence number
+   * @param timeToLive
+   *   time-to-live duration from now
+   */
+  def setExpiryForAllEventsAndSnapshots(
+      persistenceIds: JList[String],
+      resetSequenceNumber: Boolean,
+      timeToLive: Duration): CompletionStage[Done] =
+    delegate
+      .setExpiryForAllEventsAndSnapshots(persistenceIds.asScala.toVector, resetSequenceNumber, timeToLive.toScala)
+      .asJava
 
 }

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/SerializedJournalItem.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/SerializedJournalItem.scala
@@ -48,4 +48,6 @@ final case class SerializedEventMetadata(serId: Int, serManifest: String, payloa
   val MetaSerManifest = "meta_ser_manifest"
   val MetaPayload = "meta_payload"
   val Deleted = "del"
+  val Expiry = "expiry"
+  val ExpiryMarker = "expiry_marker"
 }

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/SerializedSnapshotItem.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/SerializedSnapshotItem.scala
@@ -42,4 +42,5 @@ final case class SerializedSnapshotMetadata(serId: Int, serManifest: String, pay
   val MetaSerId = "meta_ser_id"
   val MetaSerManifest = "meta_ser_manifest"
   val MetaPayload = "meta_payload"
+  val Expiry = "expiry"
 }

--- a/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
@@ -4,6 +4,12 @@
 
 package akka.persistence.dynamodb.cleanup
 
+import java.time.Instant
+
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
@@ -19,7 +25,11 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.persistence.dynamodb.cleanup.scaladsl.EventSourcedCleanup
 import com.typesafe.config.Config
+import org.scalatest.Inspectors
+import org.scalatest.OptionValues
 import org.slf4j.event.Level
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest
 
 object EventSourcedCleanupSpec {
   val config: Config = ConfigFactory
@@ -35,6 +45,8 @@ object EventSourcedCleanupSpec {
 class EventSourcedCleanupSpec
     extends ScalaTestWithActorTestKit(EventSourcedCleanupSpec.config)
     with AnyWordSpecLike
+    with Inspectors
+    with OptionValues
     with TestDbLifecycle
     with TestData
     with LogCapturing {
@@ -94,7 +106,6 @@ class EventSourcedCleanupSpec
           val from = (iteration * batchSize) + 1
           iteration = iteration + 1
           val to = Math.min(maxSeqNumber, from + batchSize - 1)
-          val deleted = to - from + 1
           val expectedMsg = s"Deleted events from [$from] to [$to] for persistenceId [$pid], consumed [8.0] WCU"
           event.message == expectedMsg
         }
@@ -161,7 +172,6 @@ class EventSourcedCleanupSpec
           val from = (iteration * batchSize) + 1
           iteration = iteration + 1
           val to = Math.min(maxSeqNumber, from + batchSize - 1)
-          val deleted = to - from + 1
           val expectedMsg = s"Deleted events from [$from] to [$to] for persistenceId [$pid], consumed [8.0] WCU"
           event.message == expectedMsg
         }
@@ -413,5 +423,1079 @@ class EventSourcedCleanupSpec
     //   eventsAfter.filter(_.persistenceId == pid2.id).last.sequenceNr shouldBe eventsBefore.last.sequenceNr
     // }
 
+    "set expiry for selected events for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val x = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForEvents(pid, toSequenceNr = x, expiryTimestamp).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < x) {
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else if (seqNr == x) { // expiry marker at x
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        } else {
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+    }
+
+    "set expiry with time-to-live duration for selected events for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val x = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForEvents(pid, toSequenceNr = x, timeToLive).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < x) {
+          eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else if (seqNr == x) { // expiry marker at x
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+        } else {
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+    }
+
+    "set expiry for selected events for single persistence id in batches" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 300
+      val x = 234
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+
+      var iteration = 0
+      val batchSize = 100 // hard-coded TransactWriteItems limit
+
+      LoggingTestKit
+        .debug("Updated expiry of events")
+        .withOccurrences((x - 1) / 100 + 1)
+        .withCustom { event =>
+          val from = (iteration * batchSize) + 1
+          iteration = iteration + 1
+          val to = Math.min(x, from + batchSize - 1)
+          val expectedMessage =
+            s"Updated expiry of events for persistenceId [$pid], for sequence numbers [$from] to [$to]," +
+            s" expiring at [$expiryTimestamp], consumed [8.0] WCU"
+          event.message == expectedMessage
+        }
+        .expect {
+          cleanup.setExpiryForEvents(pid, toSequenceNr = x, expiryTimestamp).futureValue
+        }
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < x) {
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else if (seqNr == x) { // expiry marker at x
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        } else {
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+    }
+
+    "set expiry for all events for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = true, expiryTimestamp).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        eventItem.get(ExpiryMarker) shouldBe None
+      }
+    }
+
+    "set expiry with time-to-live duration for all events for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = true, timeToLive).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+        eventItem.get(ExpiryMarker) shouldBe None
+      }
+    }
+
+    "set expiry for all events for single persistence id in batches" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 321
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+
+      var iteration = 0
+      val batchSize = 100 // hard-coded TransactWriteItems limit
+
+      LoggingTestKit
+        .debug("Updated expiry of events")
+        .withOccurrences((n - 1) / 100 + 1)
+        .withCustom { event =>
+          val from = (iteration * batchSize) + 1
+          iteration = iteration + 1
+          val to = Math.min(n, from + batchSize - 1)
+          val expectedMessage =
+            s"Updated expiry of events for persistenceId [$pid], for sequence numbers [$from] to [$to]," +
+            s" expiring at [$expiryTimestamp], consumed [8.0] WCU"
+          event.message == expectedMessage
+        }
+        .expect {
+          cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = true, expiryTimestamp).futureValue
+        }
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        eventItem.get(ExpiryMarker) shouldBe None
+      }
+    }
+
+    "set expiry for all events for single persistence id and add expiry marker" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = false, expiryTimestamp).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < n) {
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else { // expiry marker for last event
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        }
+      }
+    }
+
+    "set expiry with time-to-live duration for all events for single persistence id and add expiry marker" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = false, timeToLive).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < n) {
+          eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else { // expiry marker for last event
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+        }
+      }
+    }
+
+    "set expiry for all events for single persistence id in batches and add expiry marker" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+      val persister = spawn(Persister(pid))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 321
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(i, ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+
+      var iteration = 0
+      val batchSize = 100 // hard-coded TransactWriteItems limit
+
+      LoggingTestKit
+        .debug("Updated expiry of events")
+        .withOccurrences((n - 1) / 100 + 1)
+        .withCustom { event =>
+          val from = (iteration * batchSize) + 1
+          iteration = iteration + 1
+          val to = Math.min(n, from + batchSize - 1)
+          val expectedMessage =
+            s"Updated expiry of events for persistenceId [$pid], for sequence numbers [$from] to [$to]," +
+            s" expiring at [$expiryTimestamp], consumed [8.0] WCU"
+          event.message == expectedMessage
+        }
+        .expect {
+          cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = false, expiryTimestamp).futureValue
+        }
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < n) {
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else { // expiry marker for last event
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        }
+      }
+    }
+
+    "set expiry for all events for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+      val persisters = pids.map(pid => spawn(Persister(pid)))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(i, ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pids, resetSequenceNumber = true, expiryTimestamp).futureValue
+
+      pids.foreach { pid =>
+        val eventItems = getEventItemsFor(pid)
+        eventItems.size shouldBe n
+        forAll(eventItems) { eventItem =>
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+    }
+
+    "set expiry with time-to-live duration for all events for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+      val persisters = pids.map(pid => spawn(Persister(pid)))
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(i, ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pids, resetSequenceNumber = true, timeToLive).futureValue
+
+      pids.foreach { pid =>
+        val eventItems = getEventItemsFor(pid)
+        eventItems.size shouldBe n
+        forAll(eventItems) { eventItem =>
+          eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+    }
+
+    "set expiry for snapshot for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = false, expiryTimestamp).futureValue
+      cleanup.setExpiryForSnapshot(pid, expiryTimestamp).futureValue
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+    }
+
+    "set expiry with time-to-live duration for snapshot for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pid, resetSequenceNumber = false, expiryTimestamp).futureValue
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      cleanup.setExpiryForSnapshot(pid, timeToLive).futureValue
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+    }
+
+    "set expiry for snapshot for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+
+      val persisters = pids.map { pid =>
+        spawn(Behaviors.setup[Persister.Command] { context =>
+          Persister
+            .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+            .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+        })
+      }
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pids, resetSequenceNumber = false, expiryTimestamp).futureValue
+      cleanup.setExpiryForSnapshots(pids, expiryTimestamp).futureValue
+
+      pids.foreach { pid =>
+        val snapshotItem = getSnapshotItemFor(pid).value
+        snapshotItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+      }
+    }
+
+    "set expiry with time-to-live duration for snapshot for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+
+      val persisters = pids.map { pid =>
+        spawn(Behaviors.setup[Persister.Command] { context =>
+          Persister
+            .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+            .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+        })
+      }
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEvents(pids, resetSequenceNumber = false, expiryTimestamp).futureValue
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      cleanup.setExpiryForSnapshots(pids, timeToLive).futureValue
+
+      pids.foreach { pid =>
+        val snapshotItem = getSnapshotItemFor(pid).value
+        snapshotItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+      }
+    }
+
+    "set expiry for events before snapshot for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForEventsBeforeSnapshot(pid, expiryTimestamp).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < s) {
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else if (seqNr == s) { // expiry marker at snapshot
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        } else {
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry) shouldBe None
+    }
+
+    "set expiry with time-to-live duration for events before snapshot for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForEventsBeforeSnapshot(pid, timeToLive).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < s) {
+          eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else if (seqNr == s) { // expiry marker at snapshot
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+        } else {
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+      }
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry) shouldBe None
+    }
+
+    "set expiry for events before snapshots for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+
+      val persisters = pids.map { pid =>
+        spawn(Behaviors.setup[Persister.Command] { context =>
+          Persister
+            .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+            .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+        })
+      }
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForEventsBeforeSnapshots(pids, expiryTimestamp).futureValue
+
+      pids.foreach { pid =>
+        val eventItems = getEventItemsFor(pid)
+        eventItems.size shouldBe n
+        forAll(eventItems) { eventItem =>
+          val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+          if (seqNr < s) {
+            eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+            eventItem.get(ExpiryMarker) shouldBe None
+          } else if (seqNr == s) { // expiry marker at snapshot
+            eventItem.get(Expiry) shouldBe None
+            eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          } else {
+            eventItem.get(Expiry) shouldBe None
+            eventItem.get(ExpiryMarker) shouldBe None
+          }
+        }
+
+        val snapshotItem = getSnapshotItemFor(pid).value
+        snapshotItem.get(Expiry) shouldBe None
+      }
+    }
+
+    "set expiry with time-to-live duration for events before snapshots for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+
+      val persisters = pids.map { pid =>
+        spawn(Behaviors.setup[Persister.Command] { context =>
+          Persister
+            .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+            .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+        })
+      }
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForEventsBeforeSnapshots(pids, timeToLive).futureValue
+
+      pids.foreach { pid =>
+        val eventItems = getEventItemsFor(pid)
+        eventItems.size shouldBe n
+        forAll(eventItems) { eventItem =>
+          val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+          if (seqNr < s) {
+            eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+            eventItem.get(ExpiryMarker) shouldBe None
+          } else if (seqNr == s) { // expiry marker at snapshot
+            eventItem.get(Expiry) shouldBe None
+            eventItem.get(ExpiryMarker).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          } else {
+            eventItem.get(Expiry) shouldBe None
+            eventItem.get(ExpiryMarker) shouldBe None
+          }
+        }
+
+        val snapshotItem = getSnapshotItemFor(pid).value
+        snapshotItem.get(Expiry) shouldBe None
+      }
+    }
+
+    "set expiry for all events and snapshot for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEventsAndSnapshot(pid, resetSequenceNumber = true, expiryTimestamp).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        eventItem.get(ExpiryMarker) shouldBe None
+      }
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+    }
+
+    "set expiry with time-to-live duration for all events and snapshot for single persistence id" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEventsAndSnapshot(pid, resetSequenceNumber = true, timeToLive).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+        eventItem.get(ExpiryMarker) shouldBe None
+      }
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+    }
+
+    "set expiry for all events and snapshot for single persistence id and add expiry marker" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEventsAndSnapshot(pid, resetSequenceNumber = false, expiryTimestamp).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < n) {
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else { // expiry marker for last event
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+        }
+      }
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+    }
+
+    "set expiry with time-to-live duration for all events and snapshot for single persistence id and add expiry marker" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pid = nextPid()
+
+      val persister = spawn(Behaviors.setup[Persister.Command] { context =>
+        Persister
+          .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+          .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+      })
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+        ackProbe.expectMessage(Done)
+      }
+
+      testKit.stop(persister)
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEventsAndSnapshot(pid, resetSequenceNumber = false, timeToLive).futureValue
+
+      val eventItems = getEventItemsFor(pid)
+      eventItems.size shouldBe n
+      forAll(eventItems) { eventItem =>
+        val seqNr = eventItem.get(SeqNr).fold(0L)(_.n.toLong)
+        if (seqNr < n) {
+          eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        } else { // expiry marker for last event
+          eventItem.get(Expiry) shouldBe None
+          eventItem.get(ExpiryMarker).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+        }
+      }
+
+      val snapshotItem = getSnapshotItemFor(pid).value
+      snapshotItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+    }
+
+    "set expiry for all events and snapshots for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+
+      val persisters = pids.map { pid =>
+        spawn(Behaviors.setup[Persister.Command] { context =>
+          Persister
+            .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+            .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+        })
+      }
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val expiryTimestamp = Instant.now().minusSeconds(1) // already expired
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEventsAndSnapshots(pids, resetSequenceNumber = true, expiryTimestamp).futureValue
+
+      pids.foreach { pid =>
+        val eventItems = getEventItemsFor(pid)
+        eventItems.size shouldBe n
+        forAll(eventItems) { eventItem =>
+          eventItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+
+        val snapshotItem = getSnapshotItemFor(pid).value
+        snapshotItem.get(Expiry).value.n.toLong shouldBe expiryTimestamp.getEpochSecond
+      }
+    }
+
+    "set expiry with time-to-live duration for all events and snapshots for multiple persistence ids" in {
+      import akka.persistence.dynamodb.internal.JournalAttributes._
+
+      val pids = Seq(nextPid(), nextPid(), nextPid())
+
+      val persisters = pids.map { pid =>
+        spawn(Behaviors.setup[Persister.Command] { context =>
+          Persister
+            .eventSourcedBehavior(PersistenceId.ofUniqueId(pid), context)
+            .snapshotWhen((_, event, _) => event.toString.contains("snap"))
+        })
+      }
+
+      val ackProbe = createTestProbe[Done]()
+
+      val n = 10
+      val s = 5
+
+      (1 to n).foreach { i =>
+        persisters.foreach { persister =>
+          persister ! Persister.PersistWithAck(s"${if (i == s) i + "-snap" else i}", ackProbe.ref)
+          ackProbe.expectMessage(Done)
+        }
+      }
+
+      persisters.foreach(persister => testKit.stop(persister))
+
+      val timeToLive = 1.minute
+      val beforeTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds) // same second or before
+
+      val cleanup = new EventSourcedCleanup(system)
+      cleanup.setExpiryForAllEventsAndSnapshots(pids, resetSequenceNumber = true, timeToLive).futureValue
+
+      pids.foreach { pid =>
+        val eventItems = getEventItemsFor(pid)
+        eventItems.size shouldBe n
+        forAll(eventItems) { eventItem =>
+          eventItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+          eventItem.get(ExpiryMarker) shouldBe None
+        }
+
+        val snapshotItem = getSnapshotItemFor(pid).value
+        snapshotItem.get(Expiry).value.n.toLong should be >= beforeTimestamp.getEpochSecond
+      }
+    }
+
+  }
+
+  def getEventItemsFor(persistenceId: String): Seq[Map[String, AttributeValue]] = {
+    import akka.persistence.dynamodb.internal.JournalAttributes.Pid
+    val request = QueryRequest.builder
+      .tableName(settings.journalTable)
+      .consistentRead(true)
+      .keyConditionExpression(s"$Pid = :pid")
+      .expressionAttributeValues(Map(":pid" -> AttributeValue.fromS(persistenceId)).asJava)
+      .build()
+    client.query(request).asScala.futureValue.items.asScala.toSeq.map(_.asScala.toMap)
+  }
+
+  def getSnapshotItemFor(persistenceId: String): Option[Map[String, AttributeValue]] = {
+    import akka.persistence.dynamodb.internal.SnapshotAttributes.Pid
+    val request = QueryRequest.builder
+      .tableName(settings.snapshotTable)
+      .consistentRead(true)
+      .keyConditionExpression(s"$Pid = :pid")
+      .expressionAttributeValues(Map(":pid" -> AttributeValue.fromS(persistenceId)).asJava)
+      .build()
+    client.query(request).asScala.futureValue.items.asScala.headOption.map(_.asScala.toMap)
   }
 }

--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -18,12 +18,18 @@ Then a background task can clean up the events and snapshots for the deleted ent
 @apidoc[EventSourcedCleanup] tool. The entity itself knows about the terminal state from the deleted event and should
 not emit further events after that, and typically stop itself if it receives any further commands.
 
+Rather than deleting immediately, the @apidoc[EventSourcedCleanup] tool can also be used to set an expiration timestamp
+on events or snapshots. DynamoDB's [Time to Live (TTL)][ttl] feature can then be enabled, to automatically delete items
+after they have expired. The TTL attribute to use for events or snapshots is named `expiry`.
+
+[ttl]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
+
 @apidoc[EventSourcedCleanup] operations include:
 
-* Delete all events and snapshots for one or many persistence ids
-* Delete all events for one or many persistence ids
-* Delete all snapshots for one or many persistence ids
-* Delete events before snapshot for one or many persistence ids
+* Delete or set expiry for all events and snapshots for one or many persistence ids
+* Delete or set expiry for all events for one or many persistence ids
+* Delete or set expiry for all snapshots for one or many persistence ids
+* Delete or set expiry for events before snapshot for one or many persistence ids
 <!-- TODO: * Delete events before a timestamp -->
 
 @@@ warning

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -81,3 +81,11 @@ don't reuse the same sequence numbers that have been deleted.
 
 See the @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) for more information about how to delete
 events, snapshots, and tombstone records.
+
+### Time to Live (TTL)
+
+Rather than deleting items immediately, the @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) can
+also be used to set an expiration timestamp on events or snapshots. DynamoDB's [Time to Live (TTL)][ttl] feature can
+then be enabled, to automatically delete items after they have expired.
+
+[ttl]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html


### PR DESCRIPTION
Refs #26 and #27

Support setting an expiry timestamp or time to live duration on events and snapshots using the cleanup tool. Mirrors deletion with the cleanup tool, but setting an `expiry` attribute. Uses a separate `expiry_marker` in place of tombstones.

I'll follow up with adding an option for checking the expiry on replay or other operations — so that any expired events and snapshots can be considered deleted. DynamoDB deletes expired items within a few days of their expiration time, and expect deletes could happen in any order, so this would protect against unexpected behaviour if persistence ids are reused. Also useful if we support adding the expiry in place of delete on snapshot or generally on item creation.

Not sure if we also want to support clearing the expiry. Currently could update again with a much later expiry to delay deletion, but can't remove.