### PR TITLE
feat: add check-expiry option for safeguarding expiration

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -119,6 +119,17 @@ akka.persistence.dynamodb {
 }
 // #cleanup-settings
 
+// #time-to-live-settings
+akka.persistence.dynamodb {
+  # Time to Live (TTL) settings
+  time-to-live {
+    # Whether to check the expiry of events or snapshots and treat as already deleted when replaying.
+    # This enforces expiration before DynamoDB Time to Live may have actually deleted the data.
+    check-expiry = off
+  }
+}
+// #time-to-live-settings
+
 // #client-settings
 akka.persistence.dynamodb {
   client {

--- a/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
@@ -41,7 +41,15 @@ object DynamoDBSettings {
 
     val cleanupSettings = new CleanupSettings(config.getConfig("cleanup"))
 
-    new DynamoDBSettings(journalTable, journalPublishEvents, snapshotTable, querySettings, cleanupSettings)
+    val timeToLiveSettings = new TimeToLiveSettings(config.getConfig("time-to-live"))
+
+    new DynamoDBSettings(
+      journalTable,
+      journalPublishEvents,
+      snapshotTable,
+      querySettings,
+      cleanupSettings,
+      timeToLiveSettings)
   }
 
   /**
@@ -57,7 +65,8 @@ final class DynamoDBSettings private (
     val journalPublishEvents: Boolean,
     val snapshotTable: String,
     val querySettings: QuerySettings,
-    val cleanupSettings: CleanupSettings) {
+    val cleanupSettings: CleanupSettings,
+    val timeToLiveSettings: TimeToLiveSettings) {
 
   val journalBySliceGsi: String = journalTable + "_slice_idx"
   val snapshotBySliceGsi: String = snapshotTable + "_slice_idx"
@@ -239,4 +248,12 @@ final class PublishEventsDynamicSettings(config: Config) {
 @InternalStableApi
 final class CleanupSettings(config: Config) {
   val logProgressEvery: Int = config.getInt("log-progress-every")
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+final class TimeToLiveSettings(config: Config) {
+  val checkExpiry: Boolean = config.getBoolean("check-expiry")
 }

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -88,4 +88,17 @@ Rather than deleting items immediately, the @ref[EventSourcedCleanup tool](clean
 also be used to set an expiration timestamp on events or snapshots. DynamoDB's [Time to Live (TTL)][ttl] feature can
 then be enabled, to automatically delete items after they have expired.
 
+An expiry marker is kept in the event journal when all events for a persistence id have been marked for expiration, in
+the same way that a tombstone record is used for hard deletes. This expiry marker keeps track of the latest sequence
+number so that subsequent events don't reuse the same sequence numbers for events that have expired.
+
+If persistence ids will be reused with possibly expired events or snapshots, then it's recommended to enable a
+`check-expiry` feature, where expired events or snapshots are treated as already deleted when replaying from the
+journal. This enforces expiration before DynamoDB Time to Live may have actually deleted the data, and protects against
+partially deleted data. Enable expiry checks with configuration:
+
+```
+akka.persistence.dynamodb.time-to-live.check-expiry = on
+```
+
 [ttl]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html


### PR DESCRIPTION
Refs #27. Follow-up to #61.

DynamoDB TTL deletes expired items within a few days of their expiration time, and deletes could happen in any order. Add a `check-expiry` feature, so that any expired events and snapshots can be considered as deleted. This protects against unexpected behaviour if persistence ids are reused. Also handle the expiry marker in the same way as the delete marker.
