### PR TITLE
feat: support time to live in place of deletes

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -126,6 +126,11 @@ akka.persistence.dynamodb {
     # Whether to check the expiry of events or snapshots and treat as already deleted when replaying.
     # This enforces expiration before DynamoDB Time to Live may have actually deleted the data.
     check-expiry = off
+
+    # Set a time-to-live duration in place of deletes when events or snapshots are deleted by an entity
+    # (such as when events are deleted on snapshot). Set to a duration to expire items after this time
+    # following the triggered deletion. Disabled when set to `off` or `none`.
+    use-time-to-live-for-deletes = off
   }
 }
 // #time-to-live-settings

--- a/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
@@ -7,8 +7,6 @@ package akka.persistence.dynamodb.cleanup
 import java.time.Instant
 
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
-import scala.jdk.FutureConverters._
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.LogCapturing
@@ -1721,27 +1719,5 @@ class EventSourcedCleanupSpec
       }
     }
 
-  }
-
-  def getEventItemsFor(persistenceId: String): Seq[Map[String, AttributeValue]] = {
-    import akka.persistence.dynamodb.internal.JournalAttributes.Pid
-    val request = QueryRequest.builder
-      .tableName(settings.journalTable)
-      .consistentRead(true)
-      .keyConditionExpression(s"$Pid = :pid")
-      .expressionAttributeValues(Map(":pid" -> AttributeValue.fromS(persistenceId)).asJava)
-      .build()
-    client.query(request).asScala.futureValue.items.asScala.toSeq.map(_.asScala.toMap)
-  }
-
-  def getSnapshotItemFor(persistenceId: String): Option[Map[String, AttributeValue]] = {
-    import akka.persistence.dynamodb.internal.SnapshotAttributes.Pid
-    val request = QueryRequest.builder
-      .tableName(settings.snapshotTable)
-      .consistentRead(true)
-      .keyConditionExpression(s"$Pid = :pid")
-      .expressionAttributeValues(Map(":pid" -> AttributeValue.fromS(persistenceId)).asJava)
-      .build()
-    client.query(request).asScala.futureValue.items.asScala.headOption.map(_.asScala.toMap)
   }
 }

--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -20,7 +20,7 @@ not emit further events after that, and typically stop itself if it receives any
 
 Rather than deleting immediately, the @apidoc[EventSourcedCleanup] tool can also be used to set an expiration timestamp
 on events or snapshots. DynamoDB's [Time to Live (TTL)][ttl] feature can then be enabled, to automatically delete items
-after they have expired. The TTL attribute to use for events or snapshots is named `expiry`.
+after they have expired. The TTL attribute to use for the journal or snapshot tables is named `expiry`.
 
 [ttl]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
 

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -82,11 +82,21 @@ don't reuse the same sequence numbers that have been deleted.
 See the @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) for more information about how to delete
 events, snapshots, and tombstone records.
 
-### Time to Live (TTL)
+## Time to Live (TTL)
 
-Rather than deleting items immediately, the @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) can
-also be used to set an expiration timestamp on events or snapshots. DynamoDB's [Time to Live (TTL)][ttl] feature can
-then be enabled, to automatically delete items after they have expired.
+Rather than deleting items immediately, an expiration timestamp can be set on events or snapshots. DynamoDB's [Time to
+Live (TTL)][ttl] feature can then be enabled, to automatically delete items after they have expired.
+
+The TTL attribute to use for the journal or snapshot tables is named `expiry`.
+
+If events are being @extref:[deleted on snapshot](akka:typed/persistence-snapshot.html#event-deletion), the journal can
+be configured to instead set an expiry time for the deleted events, given a time-to-live duration to use. For example,
+deleted events can be configured to expire in 7 days, rather than being deleted immediately:
+
+@@ snip [use time-to-live for deletes](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #use-time-to-live-for-deletes type=conf }
+
+The @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) can also be used to set an expiration
+timestamp on events or snapshots.
 
 An expiry marker is kept in the event journal when all events for a persistence id have been marked for expiration, in
 the same way that a tombstone record is used for hard deletes. This expiry marker keeps track of the latest sequence
@@ -97,8 +107,12 @@ If persistence ids will be reused with possibly expired events or snapshots, the
 journal. This enforces expiration before DynamoDB Time to Live may have actually deleted the data, and protects against
 partially deleted data. Enable expiry checks with configuration:
 
-```
-akka.persistence.dynamodb.time-to-live.check-expiry = on
-```
+@@ snip [check expiry](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #check-expiry type=conf }
+
+### Time to Live reference configuration
+
+The following can be overridden in your `application.conf` for the time-to-live specific settings:
+
+@@snip [reference.conf](/core/src/main/resources/reference.conf) { #time-to-live-settings }
 
 [ttl]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html

--- a/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala
+++ b/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.config
+
+import scala.concurrent.duration._
+
+import akka.persistence.dynamodb.DynamoDBSettings
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+object TimeToLiveSettingsDocExample {
+
+  val checkExpiryConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    //#check-expiry
+    akka.persistence.dynamodb.time-to-live {
+     check-expiry = on
+    }
+    //#check-expiry
+    """))
+
+  val ttlForDeletesConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    //#use-time-to-live-for-deletes
+    akka.persistence.dynamodb.time-to-live {
+      use-time-to-live-for-deletes = 7 days
+    }
+    //#use-time-to-live-for-deletes
+    """))
+}
+
+class TimeToLiveSettingsDocExample extends AnyWordSpec with Matchers {
+  import TimeToLiveSettingsDocExample._
+
+  def dynamoDBSettings(config: Config): DynamoDBSettings =
+    DynamoDBSettings(config.getConfig("akka.persistence.dynamodb"))
+
+  "Journal Time to Live (TTL) docs" should {
+
+    "have example of setting check-expiry" in {
+      val settings = dynamoDBSettings(checkExpiryConfig)
+      settings.timeToLiveSettings.checkExpiry shouldBe true
+      settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe None
+    }
+
+    "have example of setting use-time-to-live-for-deletes" in {
+      val settings = dynamoDBSettings(ttlForDeletesConfig)
+      settings.timeToLiveSettings.checkExpiry shouldBe false
+      settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe Some(7.days)
+    }
+
+  }
+}

--- a/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -367,7 +367,7 @@ class DynamoDBTimestampOffsetStoreSpec
         if (i % 1000 == 0) {
           val totalDurationMs = (System.nanoTime() - totalStartTime) / 1000 / 1000
           val durationMs = (System.nanoTime() - startTime) / 1000 / 1000
-          println(
+          log.debug(
             s"#${i * batchSize}: $count took $durationMs ms, RPS ${1000L * count / durationMs}, Total RPS ${1000L * i * batchSize / totalDurationMs}")
           startTime = System.nanoTime()
           count = 0


### PR DESCRIPTION
Refs #27 

Allow a TTL expiry to be used as alternative to directly deleting events or snapshots.