### PR TITLE
feat: support time to live when writing events or snapshots

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -131,6 +131,14 @@ akka.persistence.dynamodb {
     # (such as when events are deleted on snapshot). Set to a duration to expire items after this time
     # following the triggered deletion. Disabled when set to `off` or `none`.
     use-time-to-live-for-deletes = off
+
+    # Set a time-to-live duration on all events when they are originally created and stored.
+    # Disabled when set to `off` or `none`.
+    event-time-to-live = off
+
+    # Set a time-to-live duration on all snapshots when they are originally created and stored.
+    # Disabled when set to `off` or `none`.
+    snapshot-time-to-live = off
   }
 }
 // #time-to-live-settings

--- a/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
@@ -239,6 +239,10 @@ final class TimeToLiveSettings(config: Config) {
 
   val useTimeToLiveForDeletes: Option[FiniteDuration] =
     ConfigHelpers.optDuration(config, "use-time-to-live-for-deletes")
+
+  val eventTimeToLive: Option[FiniteDuration] = ConfigHelpers.optDuration(config, "event-time-to-live")
+
+  val snapshotTimeToLive: Option[FiniteDuration] = ConfigHelpers.optDuration(config, "snapshot-time-to-live")
 }
 
 private[dynamodb] object ConfigHelpers {

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
@@ -86,6 +86,11 @@ import software.amazon.awssdk.services.dynamodb.model.Update
         attributes.put(MetaPayload, AttributeValue.fromB(SdkBytes.fromByteArray(meta.payload)))
       }
 
+      settings.timeToLiveSettings.eventTimeToLive.foreach { timeToLive =>
+        val expiryTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds)
+        attributes.put(Expiry, AttributeValue.fromN(expiryTimestamp.getEpochSecond.toString))
+      }
+
       attributes
     }
 

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/SnapshotDao.scala
@@ -144,6 +144,11 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
       attributes.put(MetaPayload, AttributeValue.fromB(SdkBytes.fromByteArray(meta.payload)))
     }
 
+    settings.timeToLiveSettings.snapshotTimeToLive.foreach { timeToLive =>
+      val expiryTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds)
+      attributes.put(Expiry, AttributeValue.fromN(expiryTimestamp.getEpochSecond.toString))
+    }
+
     val request = PutItemRequest
       .builder()
       .tableName(settings.snapshotTable)

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -95,6 +95,12 @@ deleted events can be configured to expire in 7 days, rather than being deleted 
 
 @@ snip [use time-to-live for deletes](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #use-time-to-live-for-deletes type=conf }
 
+While it is recommended to keep all events in an event sourced system, so that new @ref:[projections](projection.md)
+can be re-built, setting a time to live expiry on events or snapshots when they are created and stored is supported.
+For example, events can be configured to expire in 3 days and snapshots in 5 days, using configuration:
+
+@@ snip [event and snapshot time-to-live](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #time-to-live type=conf }
+
 The @ref[EventSourcedCleanup tool](cleanup.md#event-sourced-cleanup-tool) can also be used to set an expiration
 timestamp on events or snapshots.
 

--- a/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala
+++ b/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala
@@ -29,6 +29,15 @@ object TimeToLiveSettingsDocExample {
     }
     //#use-time-to-live-for-deletes
     """))
+
+  val ttlConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    //#time-to-live
+    akka.persistence.dynamodb.time-to-live {
+      event-time-to-live = 3 days
+      snapshot-time-to-live = 5 days
+    }
+    //#time-to-live
+    """))
 }
 
 class TimeToLiveSettingsDocExample extends AnyWordSpec with Matchers {
@@ -49,6 +58,14 @@ class TimeToLiveSettingsDocExample extends AnyWordSpec with Matchers {
       val settings = dynamoDBSettings(ttlForDeletesConfig)
       settings.timeToLiveSettings.checkExpiry shouldBe false
       settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe Some(7.days)
+    }
+
+    "have example of setting event-time-to-live and snapshot-time-to-live" in {
+      val settings = dynamoDBSettings(ttlConfig)
+      settings.timeToLiveSettings.checkExpiry shouldBe false
+      settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe None
+      settings.timeToLiveSettings.eventTimeToLive shouldBe Some(3.days)
+      settings.timeToLiveSettings.snapshotTimeToLive shouldBe Some(5.days)
     }
 
   }


### PR DESCRIPTION
Refs #27 

Add options to set TTL on events and snapshots when they're persisted. More cost effective, avoiding the additional writes to set an expiry later, but obviously needs to be used with care. We could also allow it to be configurable per entity type, instead of for all entity types as it is now. But the cleanup tool can also be used for finer programmatic control.