### PR TITLE
fix: reuse write timestamp for expiry

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
@@ -87,7 +87,7 @@ import software.amazon.awssdk.services.dynamodb.model.Update
       }
 
       settings.timeToLiveSettings.eventTimeToLive.foreach { timeToLive =>
-        val expiryTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds)
+        val expiryTimestamp = item.writeTimestamp.plusSeconds(timeToLive.toSeconds)
         attributes.put(Expiry, AttributeValue.fromN(expiryTimestamp.getEpochSecond.toString))
       }
 

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/SnapshotDao.scala
@@ -145,7 +145,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
     }
 
     settings.timeToLiveSettings.snapshotTimeToLive.foreach { timeToLive =>
-      val expiryTimestamp = Instant.now().plusSeconds(timeToLive.toSeconds)
+      val expiryTimestamp = snapshot.writeTimestamp.plusSeconds(timeToLive.toSeconds)
       attributes.put(Expiry, AttributeValue.fromN(expiryTimestamp.getEpochSecond.toString))
     }
 


### PR DESCRIPTION
Follow-up to #64

Small adjustment to reuse the already created write timestamp for TTL expiry, rather than create another now instant.