### PR TITLE
feat: time-to-live settings per entity type

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -123,22 +123,38 @@ akka.persistence.dynamodb {
 akka.persistence.dynamodb {
   # Time to Live (TTL) settings
   time-to-live {
-    # Whether to check the expiry of events or snapshots and treat as already deleted when replaying.
-    # This enforces expiration before DynamoDB Time to Live may have actually deleted the data.
-    check-expiry = off
+    event-sourced-defaults {
+      # Whether to check the expiry of events or snapshots and treat as already deleted when replaying.
+      # This enforces expiration before DynamoDB Time to Live may have actually deleted the data.
+      check-expiry = on
 
-    # Set a time-to-live duration in place of deletes when events or snapshots are deleted by an entity
-    # (such as when events are deleted on snapshot). Set to a duration to expire items after this time
-    # following the triggered deletion. Disabled when set to `off` or `none`.
-    use-time-to-live-for-deletes = off
+      # Set a time-to-live duration in place of deletes when events or snapshots are deleted by an entity
+      # (such as when events are deleted on snapshot). Set to a duration to expire items after this time
+      # following the triggered deletion. Disabled when set to `off` or `none`.
+      use-time-to-live-for-deletes = off
 
-    # Set a time-to-live duration on all events when they are originally created and stored.
-    # Disabled when set to `off` or `none`.
-    event-time-to-live = off
+      # Set a time-to-live duration on all events when they are originally created and stored.
+      # Disabled when set to `off` or `none`.
+      event-time-to-live = off
 
-    # Set a time-to-live duration on all snapshots when they are originally created and stored.
-    # Disabled when set to `off` or `none`.
-    snapshot-time-to-live = off
+      # Set a time-to-live duration on all snapshots when they are originally created and stored.
+      # Disabled when set to `off` or `none`.
+      snapshot-time-to-live = off
+    }
+
+    # Time-to-live settings per entity type for event sourced entities.
+    # See `event-sourced-defaults` for possible settings and default values.
+    # Prefix matching is supported by using * at the end of an entity type key.
+    event-sourced-entities {
+      # Example configuration:
+      # "some-entity-type" {
+      #   use-time-to-live-for-deletes = 7 days
+      # }
+      # "entity-type-*" {
+      #   event-time-to-live = 3 days
+      #   snapshot-time-to-live = 5 days
+      # }
+    }
   }
 }
 // #time-to-live-settings

--- a/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/cleanup/EventSourcedCleanupSpec.scala
@@ -26,8 +26,6 @@ import com.typesafe.config.Config
 import org.scalatest.Inspectors
 import org.scalatest.OptionValues
 import org.slf4j.event.Level
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue
-import software.amazon.awssdk.services.dynamodb.model.QueryRequest
 
 object EventSourcedCleanupSpec {
   val config: Config = ConfigFactory
@@ -35,9 +33,6 @@ object EventSourcedCleanupSpec {
     akka.loglevel = DEBUG
     akka.persistence.dynamodb.cleanup {
       log-progress-every = 2
-    }
-    akka.persistence.dynamodb.time-to-live {
-      check-expiry = on
     }
   """)
     .withFallback(TestConfig.config)

--- a/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
@@ -36,9 +36,12 @@ object DynamoDBJournalSpec {
     ConfigFactory
       .parseString("""
         akka.persistence.dynamodb.time-to-live {
-          # check expiry and set zero TTL for testing as if deleted immediately
-          check-expiry = on
-          use-time-to-live-for-deletes = 0 seconds
+          event-sourced-entities {
+            "*" {
+              # check expiry by default and set zero TTL for testing as if deleted immediately
+              use-time-to-live-for-deletes = 0 seconds
+            }
+          }
         }
       """)
       .withFallback(DynamoDBJournalSpec.testConfig())
@@ -47,8 +50,11 @@ object DynamoDBJournalSpec {
     ConfigFactory
       .parseString("""
         akka.persistence.dynamodb.time-to-live {
-          check-expiry = on
-          event-time-to-live = 1 hour
+          event-sourced-entities {
+            "*" {
+              event-time-to-live = 1 hour
+            }
+          }
         }
       """)
       .withFallback(DynamoDBJournalSpec.testConfig())

--- a/core/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStoreSpec.scala
@@ -33,9 +33,12 @@ object DynamoDBSnapshotStoreSpec {
     ConfigFactory
       .parseString("""
         akka.persistence.dynamodb.time-to-live {
-          # check expiry and set zero TTL for testing as if deleted immediately
-          check-expiry = on
-          use-time-to-live-for-deletes = 0 seconds
+          event-sourced-entities {
+            "*" {
+              # check expiry by default and set zero TTL for testing as if deleted immediately
+              use-time-to-live-for-deletes = 0 seconds
+            }
+          }
         }
       """)
       .withFallback(config)
@@ -44,8 +47,11 @@ object DynamoDBSnapshotStoreSpec {
     ConfigFactory
       .parseString("""
         akka.persistence.dynamodb.time-to-live {
-          check-expiry = on
-          snapshot-time-to-live = 1 hour
+          event-sourced-entities {
+            "*" {
+              snapshot-time-to-live = 1 hour
+            }
+          }
         }
       """)
       .withFallback(config)

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -89,15 +89,20 @@ Live (TTL)][ttl] feature can then be enabled, to automatically delete items afte
 
 The TTL attribute to use for the journal or snapshot tables is named `expiry`.
 
+Time-to-live settings are configured per entity type. The entity type can also be matched by prefix by using a `*` at
+the end of the key.
+
 If events are being @extref:[deleted on snapshot](akka:typed/persistence-snapshot.html#event-deletion), the journal can
 be configured to instead set an expiry time for the deleted events, given a time-to-live duration to use. For example,
-deleted events can be configured to expire in 7 days, rather than being deleted immediately:
+deleted events can be configured to expire in 7 days, rather than being deleted immediately, for a particular entity
+type:
 
 @@ snip [use time-to-live for deletes](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #use-time-to-live-for-deletes type=conf }
 
 While it is recommended to keep all events in an event sourced system, so that new @ref:[projections](projection.md)
 can be re-built, setting a time to live expiry on events or snapshots when they are created and stored is supported.
-For example, events can be configured to expire in 3 days and snapshots in 5 days, using configuration:
+For example, events can be configured to expire in 3 days and snapshots in 5 days, for all entity type names that start
+with a particular prefix:
 
 @@ snip [event and snapshot time-to-live](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #time-to-live type=conf }
 
@@ -108,12 +113,10 @@ An expiry marker is kept in the event journal when all events for a persistence 
 the same way that a tombstone record is used for hard deletes. This expiry marker keeps track of the latest sequence
 number so that subsequent events don't reuse the same sequence numbers for events that have expired.
 
-If persistence ids will be reused with possibly expired events or snapshots, then it's recommended to enable a
-`check-expiry` feature, where expired events or snapshots are treated as already deleted when replaying from the
-journal. This enforces expiration before DynamoDB Time to Live may have actually deleted the data, and protects against
-partially deleted data. Enable expiry checks with configuration:
-
-@@ snip [check expiry](/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala) { #check-expiry type=conf }
+In case persistence ids will be reused with possibly expired events or snapshots, there is a `check-expiry` feature
+enabled by default, where expired events or snapshots are treated as already deleted when replaying from the journal.
+This enforces expiration before DynamoDB Time to Live may have actually deleted the data, and protects against
+partially deleted data.
 
 ### Time to Live reference configuration
 

--- a/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala
+++ b/docs/src/test/scala/docs/config/TimeToLiveSettingsDocExample.scala
@@ -14,18 +14,14 @@ import org.scalatest.wordspec.AnyWordSpec
 
 object TimeToLiveSettingsDocExample {
 
-  val checkExpiryConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
-    //#check-expiry
-    akka.persistence.dynamodb.time-to-live {
-     check-expiry = on
-    }
-    //#check-expiry
-    """))
-
   val ttlForDeletesConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
     //#use-time-to-live-for-deletes
     akka.persistence.dynamodb.time-to-live {
-      use-time-to-live-for-deletes = 7 days
+      event-sourced-entities {
+        "some-entity-type" {
+          use-time-to-live-for-deletes = 7 days
+        }
+      }
     }
     //#use-time-to-live-for-deletes
     """))
@@ -33,8 +29,12 @@ object TimeToLiveSettingsDocExample {
   val ttlConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
     //#time-to-live
     akka.persistence.dynamodb.time-to-live {
-      event-time-to-live = 3 days
-      snapshot-time-to-live = 5 days
+      event-sourced-entities {
+        "entity-type-*" {
+          event-time-to-live = 3 days
+          snapshot-time-to-live = 5 days
+        }
+      }
     }
     //#time-to-live
     """))
@@ -48,24 +48,42 @@ class TimeToLiveSettingsDocExample extends AnyWordSpec with Matchers {
 
   "Journal Time to Live (TTL) docs" should {
 
-    "have example of setting check-expiry" in {
-      val settings = dynamoDBSettings(checkExpiryConfig)
-      settings.timeToLiveSettings.checkExpiry shouldBe true
-      settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe None
-    }
-
     "have example of setting use-time-to-live-for-deletes" in {
       val settings = dynamoDBSettings(ttlForDeletesConfig)
-      settings.timeToLiveSettings.checkExpiry shouldBe false
-      settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe Some(7.days)
+
+      val ttlSettings = settings.timeToLiveSettings.eventSourcedEntities.get("some-entity-type")
+      ttlSettings.checkExpiry shouldBe true
+      ttlSettings.useTimeToLiveForDeletes shouldBe Some(7.days)
+      ttlSettings.eventTimeToLive shouldBe None
+      ttlSettings.snapshotTimeToLive shouldBe None
+
+      val defaultTtlSettings = settings.timeToLiveSettings.eventSourcedEntities.get("other-entity-type")
+      defaultTtlSettings.checkExpiry shouldBe true
+      defaultTtlSettings.useTimeToLiveForDeletes shouldBe None
+      defaultTtlSettings.eventTimeToLive shouldBe None
+      defaultTtlSettings.snapshotTimeToLive shouldBe None
     }
 
     "have example of setting event-time-to-live and snapshot-time-to-live" in {
       val settings = dynamoDBSettings(ttlConfig)
-      settings.timeToLiveSettings.checkExpiry shouldBe false
-      settings.timeToLiveSettings.useTimeToLiveForDeletes shouldBe None
-      settings.timeToLiveSettings.eventTimeToLive shouldBe Some(3.days)
-      settings.timeToLiveSettings.snapshotTimeToLive shouldBe Some(5.days)
+
+      val ttlSettings1 = settings.timeToLiveSettings.eventSourcedEntities.get("entity-type-1")
+      ttlSettings1.checkExpiry shouldBe true
+      ttlSettings1.useTimeToLiveForDeletes shouldBe None
+      ttlSettings1.eventTimeToLive shouldBe Some(3.days)
+      ttlSettings1.snapshotTimeToLive shouldBe Some(5.days)
+
+      val ttlSettings2 = settings.timeToLiveSettings.eventSourcedEntities.get("entity-type-2")
+      ttlSettings2.checkExpiry shouldBe true
+      ttlSettings2.useTimeToLiveForDeletes shouldBe None
+      ttlSettings2.eventTimeToLive shouldBe Some(3.days)
+      ttlSettings2.snapshotTimeToLive shouldBe Some(5.days)
+
+      val defaultTtlSettings = settings.timeToLiveSettings.eventSourcedEntities.get("other-entity-type")
+      defaultTtlSettings.checkExpiry shouldBe true
+      defaultTtlSettings.useTimeToLiveForDeletes shouldBe None
+      defaultTtlSettings.eventTimeToLive shouldBe None
+      defaultTtlSettings.snapshotTimeToLive shouldBe None
     }
 
   }


### PR DESCRIPTION
Refs #27. Follow-up to #62 and #64.

Configuration for TTL settings are now per entity type. The check expiry feature is now always enabled by default, for all entities. The defaults can be configured separately.