### PR TITLE
feat: support time to live for projection offsets

### DIFF
--- a/docs/src/main/paradox/projection.md
+++ b/docs/src/main/paradox/projection.md
@@ -338,3 +338,25 @@ Java
 Scala
 :  @@snip [projection settings](/docs/src/test/scala/projection/docs/scaladsl/ProjectionDocExample.scala) { #projection-settings }
 
+## Time to Live (TTL)
+
+Offsets are never deleted by default. To have offsets deleted for inactive projections, an expiration timestamp can be
+set. DynamoDB's [Time to Live (TTL)][ttl] feature can then be enabled, to automatically delete items after they have
+expired. A new expiration timestamp will be set each time an offset for a particular projection slice or persistence id
+is updated.
+
+The TTL attribute to use for the timestamp offset table is named `expiry`.
+
+Time-to-live settings are configured per projection. The projection name can also be matched by prefix by using a `*`
+at the end of the key. For example, offsets can be configured to expire in 7 days for a particular projection, and in
+14 days for all projections names that start with a particular prefix:
+
+@@ snip [offset time-to-live](/docs/src/test/scala/projection/docs/config/ProjectionTimeToLiveSettingsDocExample.scala) { #time-to-live type=conf }
+
+### Time to Live reference configuration
+
+The following can be overridden in your `application.conf` for the time-to-live specific settings:
+
+@@snip [reference.conf](/projection/src/main/resources/reference.conf) { #time-to-live-settings }
+
+[ttl]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html

--- a/docs/src/test/scala/projection/docs/config/ProjectionTimeToLiveSettingsDocExample.scala
+++ b/docs/src/test/scala/projection/docs/config/ProjectionTimeToLiveSettingsDocExample.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package projection.docs.config
+
+import scala.concurrent.duration._
+
+import akka.projection.dynamodb.DynamoDBProjectionSettings
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+object ProjectionTimeToLiveSettingsDocExample {
+
+  val ttlConfig: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    //#time-to-live
+    akka.projection.dynamodb.time-to-live {
+      projections {
+        "some-projection" {
+          offset-time-to-live = 7 days
+        }
+        "projection-*" {
+          offset-time-to-live = 14 days
+        }
+      }
+    }
+    //#time-to-live
+    """))
+}
+
+class ProjectionTimeToLiveSettingsDocExample extends AnyWordSpec with Matchers {
+  import ProjectionTimeToLiveSettingsDocExample._
+
+  def dynamoDBProjectionSettings(config: Config): DynamoDBProjectionSettings =
+    DynamoDBProjectionSettings(config.getConfig("akka.projection.dynamodb"))
+
+  "Projection Time to Live (TTL) docs" should {
+
+    "have example of setting offset-time-to-live" in {
+      val settings = dynamoDBProjectionSettings(ttlConfig)
+
+      val someTtlSettings = settings.timeToLiveSettings.projections.get("some-projection")
+      someTtlSettings.offsetTimeToLive shouldBe Some(7.days)
+
+      val ttlSettings1 = settings.timeToLiveSettings.projections.get("projection-1")
+      ttlSettings1.offsetTimeToLive shouldBe Some(14.days)
+
+      val ttlSettings2 = settings.timeToLiveSettings.projections.get("projection-2")
+      ttlSettings2.offsetTimeToLive shouldBe Some(14.days)
+
+      val defaultTtlSettings = settings.timeToLiveSettings.projections.get("other-projection")
+      defaultTtlSettings.offsetTimeToLive shouldBe None
+    }
+
+  }
+}

--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -36,3 +36,29 @@ akka.projection.dynamodb {
   warn-about-filtered-events-in-flow = true
 }
 //#projection-config
+
+//#time-to-live-settings
+akka.projection.dynamodb {
+  # Time to Live (TTL) settings
+  time-to-live {
+    projection-defaults {
+      # Set a time-to-live duration on all offsets when they are updated.
+      # Disabled when set to `off` or `none`.
+      offset-time-to-live = off
+    }
+
+    # Time-to-live settings per projection name.
+    # See `projection-defaults` for possible settings and default values.
+    # Prefix matching is supported by using * at the end of an entity type key.
+    projections {
+      # Example configuration:
+      # "some-projection" {
+      #   offset-time-to-live = 7 days
+      # }
+      # "projection-*" {
+      #   offset-time-to-live = 14 days
+      # }
+    }
+  }
+}
+//#time-to-live-settings


### PR DESCRIPTION
Refs #45

Add a configurable TTL for offsets. Updated each time the offsets are updated.

Note: haven't worried about a check-expiry on load feature, like for events or snapshots.