### PR TITLE
docs: fix copy paste typos for offset time to live

### DIFF
--- a/docs/src/main/paradox/projection.md
+++ b/docs/src/main/paradox/projection.md
@@ -349,7 +349,7 @@ The TTL attribute to use for the timestamp offset table is named `expiry`.
 
 Time-to-live settings are configured per projection. The projection name can also be matched by prefix by using a `*`
 at the end of the key. For example, offsets can be configured to expire in 7 days for a particular projection, and in
-14 days for all projections names that start with a particular prefix:
+14 days for all projection names that start with a particular prefix:
 
 @@ snip [offset time-to-live](/docs/src/test/scala/projection/docs/config/ProjectionTimeToLiveSettingsDocExample.scala) { #time-to-live type=conf }
 

--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -49,7 +49,7 @@ akka.projection.dynamodb {
 
     # Time-to-live settings per projection name.
     # See `projection-defaults` for possible settings and default values.
-    # Prefix matching is supported by using * at the end of an entity type key.
+    # Prefix matching is supported by using * at the end of a projection name.
     projections {
       # Example configuration:
       # "some-projection" {


### PR DESCRIPTION
Follow-up to #73. Noticed a couple of typos after merge.