### PR TITLE
default to 'standard' retry mode

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -218,7 +218,8 @@ akka.persistence.dynamodb {
 
       # Set the retry mode. Can be `default`, `legacy`, `standard`, or `adaptive`.
       # See the documentation for the AWS SDK for Java for details.
-      retry-mode = default
+	  # As of AWS SDK 2.25.59, the default for DynamoDB is `legacy`, which is not recommended
+      retry-mode = standard
 
       # Maximum number of times that a single request should be retried, assuming it fails for a retryable error.
       # Can be `default` for the default number of retries for the `retry-mode`, or override with a specific number.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -218,7 +218,7 @@ akka.persistence.dynamodb {
 
       # Set the retry mode. Can be `default`, `legacy`, `standard`, or `adaptive`.
       # See the documentation for the AWS SDK for Java for details.
-	  # As of AWS SDK 2.25.59, the default for DynamoDB is `legacy`, which is not recommended
+      # As of AWS SDK 2.25.59, the default for DynamoDB is `legacy`, which is not recommended
       retry-mode = standard
 
       # Maximum number of times that a single request should be retried, assuming it fails for a retryable error.

--- a/core/src/test/scala/akka/persistence/dynamodb/util/ClientProviderSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/util/ClientProviderSpec.scala
@@ -54,7 +54,7 @@ class ClientProviderSpec extends AnyWordSpec with Matchers with OptionValues {
       httpSettings.tcpKeepAlive shouldBe false
 
       val retryPolicy = overrideConfiguration.retryPolicy.toScala.value
-      retryPolicy.retryMode shouldBe RetryMode.LEGACY
+      retryPolicy.retryMode shouldBe RetryMode.STANDARD
       retryPolicy.numRetries shouldBe 3
 
       val compressionConfiguration = overrideConfiguration.compressionConfiguration.toScala.value
@@ -82,7 +82,7 @@ class ClientProviderSpec extends AnyWordSpec with Matchers with OptionValues {
         }
 
         retry-policy {
-          retry-mode = standard
+          retry-mode = legacy
           num-retries = 5
         }
 
@@ -121,7 +121,7 @@ class ClientProviderSpec extends AnyWordSpec with Matchers with OptionValues {
       httpSettings.tcpKeepAlive shouldBe true
 
       val retryPolicy = overrideConfiguration.retryPolicy.toScala.value
-      retryPolicy.retryMode shouldBe RetryMode.STANDARD
+      retryPolicy.retryMode shouldBe RetryMode.LEGACY
       retryPolicy.numRetries shouldBe 5
 
       val compressionConfiguration = overrideConfiguration.compressionConfiguration.toScala.value

--- a/core/src/test/scala/akka/persistence/dynamodb/util/ClientProviderSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/util/ClientProviderSpec.scala
@@ -55,7 +55,7 @@ class ClientProviderSpec extends AnyWordSpec with Matchers with OptionValues {
 
       val retryPolicy = overrideConfiguration.retryPolicy.toScala.value
       retryPolicy.retryMode shouldBe RetryMode.STANDARD
-      retryPolicy.numRetries shouldBe 3
+      retryPolicy.numRetries shouldBe 2
 
       val compressionConfiguration = overrideConfiguration.compressionConfiguration.toScala.value
       compressionConfiguration.requestCompressionEnabled shouldBe true


### PR DESCRIPTION
The Dynamo SDK defaults the retry strategy to `legacy` (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProgrammingWithJava.html#RetryMode), presumably because older versions of the SDK used that by default.

However, the AWS docs (https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html) suggest that `legacy` is not recommended and to use `standard` instead.