### PR TITLE
Allow GSI names to be configured explicitly

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -7,6 +7,14 @@ akka.persistence.dynamodb {
     # name of the table to use for events
     table = "event_journal"
 
+    # Name of global secondary index to support queries and/or projections.
+    # "" is the default and denotes an index named "${table}_slice_idx"
+    # (viz. when table (see above) is "event_journal", the GSI will be
+    # "event_journal_slice_idx").  If for some reason an alternative GSI name
+    # is required, set that GSI name explicitly here; if set explicitly, this
+    # name will be used unmodified
+    by-slice-idx = ""
+
     # Set this to off to disable publishing of events as Akka messages to running
     # eventsBySlices queries.
     # Tradeoff is more CPU and network resources that are used. The events
@@ -55,6 +63,14 @@ akka.persistence.dynamodb {
 
     # name of the table to use for snapshots
     table = "snapshot"
+
+    # Name of global secondary index to support queries and/or projections.
+    # "" is the default and denotes an index named "${table}_slice_idx"
+    # (viz. when table (see above) is "event_journal", the GSI will be
+    # "event_journal_slice_idx").  If for some reason an alternative GSI name
+    # is required, set that GSI name explicitly here; if set explicitly, this
+    # name will be used unmodified
+    by-slice-idx = ""
 
     # Enables an optimization in Akka for avoiding snapshot deletes in retention.
     only-one-snapshot = true

--- a/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
@@ -45,15 +45,15 @@ object DynamoDBSettings {
 
     val timeToLiveSettings = new TimeToLiveSettings(config.getConfig("time-to-live"))
 
-    val journalBySliceGsi =
-      if (config.getString("journal.by-slice-idx").nonEmpty) {
-        config.getString("journal.by-slice-idx")
-      } else journalTable + "_slice_idx"
+    val journalBySliceGsi = {
+      val indexName = config.getString("journal.by-slice-idx")
+      if (indexName.nonEmpty) indexName else journalTable + "_slice_idx"
+    }
 
-    val snapshotBySliceGsi =
-      if (config.getString("snapshot.by-slice-idx").nonEmpty) {
-        config.getString("snapshot.by-slice-idx")
-      } else snapshotTable + "_slice_idx"
+    val snapshotBySliceGsi = {
+      val indexName = config.getString("snapshot.by-slice-idx")
+      if (indexName.nonEmpty) indexName else snapshotTable + "_slice_idx"
+    }
 
     new DynamoDBSettings(
       journalTable,

--- a/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
@@ -45,13 +45,25 @@ object DynamoDBSettings {
 
     val timeToLiveSettings = new TimeToLiveSettings(config.getConfig("time-to-live"))
 
+    val journalBySliceGsi =
+      if (config.getString("journal.by-slice-idx").nonEmpty) {
+        config.getString("journal.by-slice-idx")
+      } else journalTable + "_slice_idx"
+
+    val snapshotBySliceGsi =
+      if (config.getString("snapshot.by-slice-idx").nonEmpty) {
+        config.getString("snapshot.by-slice-idx")
+      } else snapshotTable + "_slice_idx"
+
     new DynamoDBSettings(
       journalTable,
       journalPublishEvents,
       snapshotTable,
       querySettings,
       cleanupSettings,
-      timeToLiveSettings)
+      timeToLiveSettings,
+      journalBySliceGsi,
+      snapshotBySliceGsi)
   }
 
   /**
@@ -68,11 +80,9 @@ final class DynamoDBSettings private (
     val snapshotTable: String,
     val querySettings: QuerySettings,
     val cleanupSettings: CleanupSettings,
-    val timeToLiveSettings: TimeToLiveSettings) {
-
-  val journalBySliceGsi: String = journalTable + "_slice_idx"
-  val snapshotBySliceGsi: String = snapshotTable + "_slice_idx"
-}
+    val timeToLiveSettings: TimeToLiveSettings,
+    val journalBySliceGsi: String,
+    val snapshotBySliceGsi: String)
 
 final class QuerySettings(config: Config) {
   val refreshInterval: FiniteDuration = config.getDuration("refresh-interval").toScala

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -24,8 +24,9 @@ An example `aws` CLI command for creating the event journal table:
 ### Indexes
 
 If @ref:[queries](query.md) or @ref:[projections](projection.md) are being used, then a global secondary index needs to
-be added to the event journal table, to index events by slice. The default name for the secondary index is
-`event_journal_slice_idx`. The following attribute definitions should be added to the event journal table, with key
+be added to the event journal table, to index events by slice. The default name (derived from the configured @ref:[table name](#tables))
+for the secondary index is `event_journal_slice_idx` and may be explicitly set (see the
+@ref:[reference configuration](#reference-configuration)). The following attribute definitions should be added to the event journal table, with key
 schema for the event journal slice index:
 
 | Attribute name    | Attribute type | Key type |

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -23,8 +23,9 @@ An example `aws` CLI command for creating the snapshot table:
 ### Indexes
 
 If @ref:[start-from-snapshot queries](query.md#eventsbyslicesstartingfromsnapshots) are being used, then a global
-secondary index needs to be added to the snapshot table, to index snapshots by slice. The default name for the
-secondary index is `snapshot_slice_idx`. The following attribute definitions should be added to the snapshot table,
+secondary index needs to be added to the snapshot table, to index snapshots by slice. The default name (derived from
+the configured @ref:[table name](#tables)) for the secondary index is `snapshot_slice_idx` and may be explicitly set
+(see the @ref:[reference configuration](#reference-configuration)). The following attribute definitions should be added to the snapshot table,
 with key schema for the snapshot slice index:
 
 | Attribute name    | Attribute type | Key type |


### PR DESCRIPTION
Currently the GSI names are hardcoded to be the journal/snapshot table names with a suffix.  There are scenarios (e.g. conformance with infrastructure-team conventions) where a different name for these indices may be desirable.

Default behavior is preserved.