### PR TITLE
use writer UUID + sequence number as a request ID for transactional writes

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
@@ -125,7 +125,13 @@ import software.amazon.awssdk.services.dynamodb.model.Update
         }.asJava
 
       val firstEvent = events.head;
-      val token = s"${firstEvent.writerUuid}-${firstEvent.seqNr.toString}"
+      val token = {
+        val base = s"${firstEvent.writerUuid}-${firstEvent.seqNr.toString}"
+        val len = base.length
+        if (len > 36) {
+          base.substring(len - 36, len)
+        } else base
+      }
 
       val req = TransactWriteItemsRequest
         .builder()

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
@@ -124,8 +124,12 @@ import software.amazon.awssdk.services.dynamodb.model.Update
             .build()
         }.asJava
 
+      val firstEvent = events.head;
+      val token = s"${firstEvent.writerUuid}-${firstEvent.seqNr.toString}"
+
       val req = TransactWriteItemsRequest
         .builder()
+        .clientRequestToken(token)
         .transactItems(writeItems)
         .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
         .build()

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/JournalDao.scala
@@ -4,9 +4,12 @@
 
 package akka.persistence.dynamodb.internal
 
+import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.concurrent.CompletionException
+import java.util.Base64
 import java.util.{ HashMap => JHashMap }
+import java.util.UUID
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -39,6 +42,7 @@ import software.amazon.awssdk.services.dynamodb.model.Update
 @InternalApi private[akka] object JournalDao {
   private val log: Logger = LoggerFactory.getLogger(classOf[JournalDao])
 
+  private val base64Encoder = Base64.getEncoder
 }
 
 /**
@@ -124,13 +128,17 @@ import software.amazon.awssdk.services.dynamodb.model.Update
             .build()
         }.asJava
 
-      val firstEvent = events.head;
       val token = {
-        val base = s"${firstEvent.writerUuid}-${firstEvent.seqNr.toString}"
-        val len = base.length
-        if (len > 36) {
-          base.substring(len - 36, len)
-        } else base
+        val firstEvent = events.head
+        val uuid = UUID.fromString(firstEvent.writerUuid)
+        val seqNr = firstEvent.seqNr
+        val bb = ByteBuffer.allocate(24)
+        bb.asLongBuffer()
+          .put(uuid.getMostSignificantBits)
+          .put(uuid.getLeastSignificantBits)
+          .put(seqNr)
+
+        new String(base64Encoder.encode(bb.array))
       }
 
       val req = TransactWriteItemsRequest


### PR DESCRIPTION
We've observed a write of multiple events failing with a `software.amazon.awssdk.services.dynamodb.model.TransactionInProgressException: Transaction from previous request is still in progress`, indicating that two concurrently executing transactional writes have the same request token.

The plugin has the AWS SDK generate the token (by not specifying one), so the underlying issue seems to be in the SDK.  This instead uses the writer UUID (unique per event-sourced actor instantiation) with the sequence number of the first event in the batch appended, to ensure uniqueness (restart of the actor will generate a new UUID, successive persists by the same actor will increment the sequence number component).