### PR TITLE
chore: Increase behind-current-time

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -100,7 +100,7 @@ akka.persistence.dynamodb {
       # not be larger than the akka.projection.dynamodb.offset-store.time-window.
       window = 2 minutes
       # Backtracking queries read events up to this duration from the current time.
-      behind-current-time = 10 seconds
+      behind-current-time = 40 seconds
     }
 
     # In-memory buffer holding events when reading from DynamoDB.


### PR DESCRIPTION
If the GSI is under heavy load some pids might be visible before others with more skew than these 10 seconds (within same slice). Then it would maybe be possible for backtracking to miss some events.