### PR TITLE
fix: only initial backtracking up to start offset when far behind

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/BySliceQuery.scala
@@ -281,7 +281,8 @@ import org.slf4j.Logger
 
       def disableBacktrackingWhenFarBehindCurrentWallClockTime: Boolean = {
         val aheadOfInitial =
-          initialOffset == TimestampOffset.Zero || state.latestBacktracking.timestamp.isAfter(initialOffset.timestamp)
+          initialOffset == TimestampOffset.Zero ||
+          state.latestBacktracking.timestamp.compareTo(initialOffset.timestamp) >= 0
 
         val previousTimestamp =
           if (state.previous == TimestampOffset.Zero) state.latest.timestamp

--- a/core/src/test/scala/akka/persistence/dynamodb/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/query/EventsBySliceBacktrackingSpec.scala
@@ -258,7 +258,7 @@ class EventsBySliceBacktrackingSpec
       result1.cancel()
     }
 
-    "still make initial backtracking until ahead of start offset" in {
+    "still make initial backtracking until caught up to start offset, then skip backtracking" in {
       val entityType = nextEntityType()
       val pid1 = nextPersistenceId(entityType)
       val slice = query.sliceForPersistenceId(pid1.id)
@@ -275,7 +275,11 @@ class EventsBySliceBacktrackingSpec
         writeEvent(slice, pid, seqNr, startTime.plusMillis(n), s"e${mod}-${seqNr}")
       }
 
-      (3 to 10).foreach { n =>
+      // will start query at next event
+      val startOffset = TimestampOffset(startTime.plusSeconds(23).plusMillis(1), Map.empty)
+
+      // go past switch-to-backtracking trigger of 3 * buffer size (of 10)
+      (3 to 30).foreach { n =>
         writeEvent(slice, pid1, n, startTime.plusSeconds(20 + n).plusMillis(1), s"e1-$n")
         writeEvent(slice, pid2, n, startTime.plusSeconds(20 + n).plusMillis(2), s"e2-$n")
       }
@@ -298,15 +302,16 @@ class EventsBySliceBacktrackingSpec
         env.offset
       }
 
-      val result1 = startQuery(TimestampOffset(startTime.plusSeconds(20), Map.empty))
+      val result1 = startQuery(startOffset)
       // from backtracking
       expect(result1.expectNext(), pid1, 1, None)
       expect(result1.expectNext(), pid2, 1, None)
       expect(result1.expectNext(), pid1, 2, None)
       expect(result1.expectNext(), pid2, 2, None)
+      expect(result1.expectNext(), pid1, 3, None) // start offset
 
       // from normal
-      (3 to 10).foreach { n =>
+      (3 to 30).foreach { n =>
         expect(result1.expectNext(), pid1, n, Some(s"e1-$n"))
         expect(result1.expectNext(), pid2, n, Some(s"e2-$n"))
       }


### PR DESCRIPTION
We've already fixed the heartbeat on backtracking idle in #104. When looking at that issue, we also noticed that there was both the initial backtracking queries up to the initial offset, and then it later switched to more backtracking, even though it was far behind. Not essential to fix this, but we can correct it now.

Update the check to be up to or ahead of the initial offset. Extend the test to cover this scenario.