### PR TITLE
bump: dynamodb 2.29.41 (was 2.25.59)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -228,18 +228,33 @@ akka.persistence.dynamodb {
     }
 
     # Retry policy settings.
-    retry-policy {
+    # DEPRECATED. Use retry-strategy settings instead.
+    // retry-policy {
+    //   # Whether retries are enabled.
+    //   enabled = on
+    //
+    //   # Set the retry mode. Can be `default`, `legacy`, `standard`, or `adaptive`.
+    //   # See the documentation for the AWS SDK for Java for details.
+    //   # As of AWS SDK 2.25.59, the default for DynamoDB is `legacy`, which is not recommended.
+    //   retry-mode = standard
+    //
+    //   # Maximum number of times that a single request should be retried, assuming it fails for a retryable error.
+    //   # Can be `default` for the default number of retries for the `retry-mode`, or override with a specific number.
+    //   num-retries = default
+    // }
+
+    retry-strategy {
       # Whether retries are enabled.
       enabled = on
 
       # Set the retry mode. Can be `default`, `legacy`, `standard`, or `adaptive`.
       # See the documentation for the AWS SDK for Java for details.
-      # As of AWS SDK 2.25.59, the default for DynamoDB is `legacy`, which is not recommended
+      # As of AWS SDK 2.25.59, the default for DynamoDB is `legacy`, which is not recommended.
       retry-mode = standard
 
-      # Maximum number of times that a single request should be retried, assuming it fails for a retryable error.
-      # Can be `default` for the default number of retries for the `retry-mode`, or override with a specific number.
-      num-retries = default
+      # Maximum number of times that a single request should be attempted (retried when it fails with a retryable error).
+      # Can be `default` for the default max attempts for the `retry-mode`, or override with a specific number.
+      max-attempts = default
     }
 
     # Request compression settings.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val AkkaProjectionVersionInDocs = VersionNumber(AkkaProjectionVersion).numbers match {
     case Seq(major, minor, _*) => s"$major.$minor"
   }
-  val AwsSdkVersion = "2.25.59"
+  val AwsSdkVersion = "2.29.41"
   // Java Platform version for JavaDoc creation
   // sync with Java version in .github/workflows/publish.yml#documentation
   val JavaDocLinkVersion = 17


### PR DESCRIPTION
Align with https://github.com/akka/akka-projection/pull/1285, and while we don't yet have scala steward registered for this repo.