### PR TITLE
chore: remove obsolete outside backtracking debug log

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/BySliceQuery.scala
@@ -222,16 +222,6 @@ import org.slf4j.Logger
           if (offset.timestamp.isBefore(state.latest.timestamp))
             throw new IllegalArgumentException(s"Unexpected offset [$offset] before latest [${state.latest}].")
 
-          if (log.isDebugEnabled()) {
-            if (state.latestBacktracking.seen.nonEmpty &&
-              offset.timestamp.isAfter(state.latestBacktracking.timestamp.plus(firstBacktrackingQueryWindow)))
-              log.debug(
-                "{} next offset is outside the backtracking window, latestBacktracking: [{}], offset: [{}]",
-                logPrefix,
-                state.latestBacktracking,
-                offset)
-          }
-
           state.copy(latest = offset, itemCount = state.itemCount + 1)
         }
       }


### PR DESCRIPTION
Now that we disable backtracking when far behind, this old debug log is not so useful — will log every offset in catch up mode. Removing it. Alternative would be to explicitly track when in catch up mode with disabled backtracking in the state, so we only log this when backtracking is enabled.