### PR TITLE
chore: scala steward ignore scala library

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,6 +9,7 @@ updates.ignore = [
   { groupId = "com.typesafe.akka" },
   { groupId = "org.scalameta", artifactId = "sbt-scalafmt" },
   { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+  { groupId = "org.scala-lang" }
 ]
 
 updatePullRequests = false


### PR DESCRIPTION
Scala version updates need to be coordinated across Akka libraries now.