### PR TITLE
fix: backtracking when fallback is enabled

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/QueryDao.scala
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse
+import scala.concurrent.Promise
 
 /**
  * INTERNAL API
@@ -41,6 +42,38 @@ import software.amazon.awssdk.services.dynamodb.model.QueryResponse
 
   private val serialization = SerializationExtension(system)
   private val fallbackStoreProvider = FallbackStoreProvider(system)
+
+  private val _backtrackingBreadcrumbSerId = Promise[Int]()
+  def backtrackingBreadcrumbSerId(): Int = {
+    _backtrackingBreadcrumbSerId.future.value match {
+      case Some(v) => v.get
+      case None =>
+        val serializerIds = serialization.bindings.iterator.map(_._2.identifier).toSet
+        // Use an unfolding iterator to find a serializer ID that's not bound.  There shouldn't ever be more
+        // than a few thousand serializer IDs bound (and the docs suggest real serializers should only have
+        // positive serializer IDs ("couple of billion")), so this shouldn't have to iterate far.
+        //
+        // Ranges that aren't indexable by an Int (viz. have more than Int.MaxValue elements) are surprisingly
+        // restrictive, thus the unfold
+        Iterator
+          .unfold(Int.MinValue) { s =>
+            if (s != Int.MaxValue) Some(s -> (s + 1))
+            else None
+          }
+          // stop fast if some other thread found this before we do
+          .find { i => !serializerIds(i) || _backtrackingBreadcrumbSerId.isCompleted } match {
+          case None =>
+            // Over 4 billion serializers... really?
+            _backtrackingBreadcrumbSerId.tryFailure(new NoSuchElementException("All serializer IDs used?"))
+
+          case Some(id) =>
+            _backtrackingBreadcrumbSerId.trySuccess(id)
+        }
+        // first get is safe, we just ensured completion
+        // second get will throw if we exhausted serializers, but that's a danger we're prepared to face...
+        _backtrackingBreadcrumbSerId.future.value.get.get
+    }
+  }
 
   private val bySliceProjectionExpression = {
     import JournalAttributes._
@@ -182,6 +215,13 @@ import software.amazon.awssdk.services.dynamodb.model.QueryResponse
   }
 
   // implements BySliceQuery.Dao
+  // NB: if backtracking and an event that was saved to the fallback store is encountered,
+  // the payload will be None (as with any backtracking event) and the serId of the returned
+  // item will be one not used by any bound serializer.
+  //
+  // Without a payload, the serializer ID is kind of meaningless (and the events-by-slice
+  // queries in the read journal will ignore the serializer ID unless it is the filtered
+  // payload serializer).
   override def itemsBySlice(
       entityType: String,
       slice: Int,
@@ -277,7 +317,8 @@ import software.amazon.awssdk.services.dynamodb.model.QueryResponse
               writeTimestamp = getTimestamp(item),
               readTimestamp = InstantFactory.now(),
               payload = None, // lazy loaded for backtracking
-              serId = item.get(EventSerId).n().toInt,
+              serId =
+                if (item.containsKey(EventSerId)) item.get(EventSerId).n().toInt else backtrackingBreadcrumbSerId(),
               serManifest = "",
               writerUuid = "", // not need in this query
               tags = if (item.containsKey(Tags)) item.get(Tags).ss().asScala.toSet else Set.empty,

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/QueryDao.scala
@@ -28,7 +28,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse
-import scala.concurrent.Promise
 
 /**
  * INTERNAL API
@@ -286,7 +285,8 @@ import scala.concurrent.Promise
               readTimestamp = InstantFactory.now(),
               payload = None, // lazy loaded for backtracking
               serId =
-                if (item.containsKey(EventSerId)) item.get(EventSerId).n().toInt else 0,  // absent or loaded later from S3
+                if (item.containsKey(EventSerId)) item.get(EventSerId).n().toInt
+                else 0, // absent or loaded later from S3
               serManifest = "",
               writerUuid = "", // not need in this query
               tags = if (item.containsKey(Tags)) item.get(Tags).ss().asScala.toSet else Set.empty,

--- a/s3-fallback-store/src/test/resources/application-test.conf
+++ b/s3-fallback-store/src/test/resources/application-test.conf
@@ -20,3 +20,7 @@ akka.persistence.dynamodb.journal.fallback-store {
 }
 
 akka.persistence.dynamodb.snapshot.fallback-store = ${akka.persistence.dynamodb.journal.fallback-store}
+
+akka.persistence.dynamodb.query.refresh-interval = 500ms
+akka.persistence.dynamodb.query.backtracking.window = 500ms
+akka.persistence.dynamodb.query.backtracking.behind-current-time = 1s


### PR DESCRIPTION
The `QueryDao` NPEs when backtracking over fallback breadcrumb items, as it expects the `EventSerId` attribute to be set, when it's not.

Fix is to use a ~dummy~ zero serializer ID for breadcrumb items when backtracking.  Since the only query for events which backtracks is the `eventsBySlice` query which only uses the serializer ID to:

* deserialize if the payload is defined (viz. not when backtracking)
* compare with the magic `FilteredPayload` serializer ID to mark the resulting envelope as filtered

any serializer ID would do; zero is chosen as it's Akka-reserved but otherwise unused ~but (for the absolute avoidance of confusion), this fix selects (on encountering the first fallback breadcrumb while backtracking) a serializer ID which is not bound to a serializer (since there are 4 billion legal serializer IDs (assuming negative IDs are allowed) and it's unlikely that a real system has even 4 thousand serializers (thus the chances are likely better than 999,999 in a million that any guess finds an unbound ID), it should be quick to find such an ID)~.  Since the by-slice queries emit event envelopes and envelopes from backtracking leave the event empty, this dummy serializer ID doesn't get exposed to the user.