### PR TITLE
chore: remove discuss.akka.io from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ The Akka family of projects is managed by teams at [Lightbend](https://lightbend
 [Akka Persistence](https://doc.akka.io/docs/akka/current/scala/persistence.html) journal and snapshot 
 store for DynamoDB. 
 
-For questions please use the [discuss.akka.io](https://discuss.akka.io). Tag any new questions with `akka-persistence` and `dynamodb`.
-
 The documentation can be found [here](https://doc.akka.io/docs/akka-persistence-dynamodb/current/index.html)
 
 ## Project status


### PR DESCRIPTION
With discuss.akka.io being read-only now, it doesn't make sense to mention it in the README
