### PR TITLE
fix: ensure that query starts from latestBacktracking in events-by-slice

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/BySliceQuery.scala
@@ -71,11 +71,8 @@ import org.slf4j.Logger
       else latest
 
     def nextQueryFromTimestamp(backtrackingWindow: JDuration): Instant =
-      if (backtracking) {
-        if (latest.timestamp.minus(backtrackingWindow).isAfter(latestBacktracking.timestamp))
-          latest.timestamp.minus(backtrackingWindow)
-        else latestBacktracking.timestamp
-      } else latest.timestamp
+      if (backtracking) latestBacktracking.timestamp
+      else latest.timestamp
 
     def nextQueryToTimestamp: Option[Instant] = {
       if (backtracking) Some(latest.timestamp)


### PR DESCRIPTION
This seems like a useful invariant to keep.  Disabling backtracking when far behind the wall-clock time preserves the motivation for #96.
