### PR TITLE
chore: Include correlation id in logs when available

### DIFF
--- a/core/src/main/scala/akka/persistence/dynamodb/internal/CorrelationId.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/CorrelationId.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024-2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.dynamodb.internal
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[dynamodb] object CorrelationId {
+  def toLogText(correlationid: Option[String]) = correlationid match {
+    case Some(id) => s", correlation [$id]"
+    case None     => ""
+  }
+}

--- a/core/src/main/scala/akka/persistence/dynamodb/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/internal/SnapshotDao.scala
@@ -449,7 +449,8 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
       slice: Int,
       fromTimestamp: Instant,
       toTimestamp: Instant,
-      backtracking: Boolean): Source[SerializedSnapshotItem, NotUsed] = {
+      backtracking: Boolean,
+      correlationId: Option[String]): Source[SerializedSnapshotItem, NotUsed] = {
     import SnapshotAttributes._
 
     val entityTypeSlice = s"$entityType-$slice"

--- a/core/src/test/scala/akka/persistence/dynamodb/query/EventsBySlicePubSubSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/query/EventsBySlicePubSubSpec.scala
@@ -224,7 +224,8 @@ class EventsBySlicePubSubSpec
           .via(
             query.skipPubSubTooFarAhead(
               enabled = true,
-              maxAheadOfBacktracking = JDuration.ofMillis(settings.querySettings.backtrackingWindow.toMillis)))
+              maxAheadOfBacktracking = JDuration.ofMillis(settings.querySettings.backtrackingWindow.toMillis),
+              correlationId = None))
           .toMat(TestSink[EventEnvelope[String]]())(Keep.both)
           .run()
       out.request(100)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val Scala3 = "3.3.7"
   val Scala2Versions = Seq(Scala213)
   val ScalaVersions = Dependencies.Scala2Versions :+ Dependencies.Scala3
-  val AkkaVersion = System.getProperty("override.akka.version", "2.10.11")
+  val AkkaVersion = System.getProperty("override.akka.version", "2.10.13")
   val AkkaVersionInDocs = VersionNumber(AkkaVersion).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
 
   // only for docs


### PR DESCRIPTION
Once https://github.com/akka/akka-projection/pull/1402 is released, this will include projection trace uuids in logs to help correlate which projection is doing what queries.