### PR TITLE
chore: link validator shouldn't fail on released version

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    - cron:  '0 6 * * 1'
+    - cron:  '30 6 1 * *'
 
 permissions:
   contents: read
@@ -14,10 +14,22 @@ jobs:
     runs-on: Akka-Default
     if: github.event.repository.fork == false
     steps:
+      - name: Checkout Global Scripts
+        # This MUST be before the main checkout or else the dynver will not work
+        uses: actions/checkout@v6
+        with:
+          repository: akka/github-actions-scripts
+          path: scripts
+          fetch-depth: 0
+
+      - name: Setup global resolver
+        run: |
+          chmod +x ./scripts/setup_global_resolver.sh
+          ./scripts/setup_global_resolver.sh
+
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        # v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v6
         with:
           # See https://github.com/actions/checkout/issues/299#issuecomment-677674415
           ref: ${{ github.event.pull_request.head.sha }}
@@ -28,19 +40,22 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        # v6.4.5
-        uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
+        # v8.0.0
+        uses: coursier/cache-action@c5ca79321d170b8a18c288d9cadc2a6037166d0f
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         # https://github.com/coursier/setup-action/releases
-        # v1.3.5
-        uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
+        # v2.0.2
+        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9
         with:
-          jvm: temurin:1.17.0.5
+          jvm: temurin:1.25
           apps: cs
 
       - name: sbt site
         run: sbt docs/makeSite
 
       - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.5 -- scripts/link-validator.conf
+        run: |
+          VERSION=$(ls docs/target/site/libraries/akka-persistence-dynamodb)
+          sed -e "s/snapshot/$VERSION/" scripts/link-validator.conf > /tmp/link-validator.conf
+          cs launch net.runne::site-link-validator:0.2.5 -- /tmp/link-validator.conf

--- a/docs/src/main/paradox/contributing.md
+++ b/docs/src/main/paradox/contributing.md
@@ -3,4 +3,4 @@
 Please feel free to contribute to Akka Persistence DynamoDB and the documentation by reporting issues you identify, or by suggesting changes to the code. 
 Please refer to our [contributing instructions](https://github.com/akka/akka-persistence-dynamodb/blob/main/CONTRIBUTING.md) to learn how it can be done.
 
-We want Akka to strive in a welcoming and open atmosphere and expect all contributors to respect our [code of conduct](https://www.lightbend.com/conduct).
+We want Akka to strive in a welcoming and open atmosphere and expect all contributors to respect our [code of conduct](https://akka.io/conduct).


### PR DESCRIPTION
Bump actions.
Global resolver scripts.
Link validator: run once a month, don't fail for no changes past release

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/akka/akka-persistence-r2dbc/pull/720