### PR TITLE
build: use global action step

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           jvm: temurin:1.11.0
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Code style check, compilation and binary-compatibility check
         run: |-
           cp .jvmopts-ci .jvmopts
@@ -76,6 +79,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.11.0
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Start DB
         run: |-
@@ -115,6 +121,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.25
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Run Paradox
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -14,18 +14,8 @@ jobs:
     runs-on: Akka-Default
     if: github.event.repository.fork == false
     steps:
-      - name: Checkout Global Scripts
-        # This MUST be before the main checkout or else the dynver will not work
-        uses: actions/checkout@v6
-        with:
-          repository: akka/github-actions-scripts
-          path: scripts
-          fetch-depth: 0
-
-      - name: Setup global resolver
-        run: |
-          chmod +x ./scripts/setup_global_resolver.sh
-          ./scripts/setup_global_resolver.sh
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Checkout
         # https://github.com/actions/checkout/releases

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           jvm: temurin:1.11
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Publish
         run: |-
           sbt +publish
@@ -61,6 +64,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.25
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Publish
         run: |-

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           jvm: ${{ matrix.JVM_NAME }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Build Target
         uses: actions/cache@v4.2.0
         with:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ The current versions of all Akka libraries are listed on the [Akka Dependencies]
 
 This library is ready to be used in production, APIs are stable, and the Lightbend subscription covers support for this project.
 
+## Build Token
+
+To build locally, you need to fetch a token at https://account.akka.io/token that you have to place into `~/.sbt/1.0/akka-commercial.sbt` file like this:
+```
+ThisBuild / resolvers += "lightbend-akka".at("your token resolver here")
+```
+
 ## License
 
 Akka is licensed under the Business Source License 1.1, please see the [Akka License FAQ](https://www.lightbend.com/akka/license-faq).

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ inThisBuild(
     description := "An Akka Persistence plugin backed by Amazon DynamoDB",
     // append -SNAPSHOT to version when isSnapshot
     dynverSonatypeSnapshots := true,
-    resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions"),
     resolvers ++=
       (if (Dependencies.AkkaVersion.endsWith("-SNAPSHOT"))
          Seq("Akka library snapshot repository".at("https://repo.akka.io/snapshots/github_actions"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0") // for maintenance of copyright file header
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.10.0")


### PR DESCRIPTION
## Summary
- Replace manual `akka/github-actions-scripts` checkout + script run in `link-validator.yml` with `uses: akka/github-actions-scripts/setup_global_resolver@main`
- Add `Run akka/github-actions-scripts` step using `akka/github-actions-scripts/setup_global_resolver@main` to all jobs in `build-test.yml`, `publish.yml`, and `weekly.yml`
- Remove `https://repo.akka.io/maven/github_actions` resolver from `build.sbt` and `project/plugins.sbt`
- Add `## Build Token` section to `README.md` with local build instructions

## Test plan
- [ ] Verify CI workflows pass with the new global resolver action step
- [ ] Confirm local builds work with the `~/.sbt/1.0/akka-commercial.sbt` token setup described in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)