### PR TITLE
bump: Update AWS SDK version to 2.46.10

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     case Seq(major, minor, _*) => s"$major.$minor"
   }
 
-  val AwsSdkVersion = "2.31.63"
+  val AwsSdkVersion = "2.46.10"
   val MinioVersion = "8.5.17"
 
   // Java Platform version for JavaDoc creation


### PR DESCRIPTION
Primarily for upstream netty bump (see https://github.com/aws/aws-sdk-java-v2/pull/7016)... among the CVEs fixed in this version are: CVE-2026-47691 and CVE-2026-45674.