### PR TITLE
feat: optional check for deserializability when persisting events & snapshots

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -355,6 +355,14 @@ akka.persistence.dynamodb {
 // #client-settings
 
 akka.persistence.dynamodb {
+  # If set to `on` (default is `off`), deserialize the item (event or snapshot) before persisting the serialized item.
+  # Enabling this prevents items which are not deserializable from being persisted, with the effect of
+  # reducing the chance of entities being unrecoverable or projections being blocked due to deserialization
+  # failures (these may still happen due to non-backward-compatible schema evolutions, but enabling this does
+  # validate that the present serialization does not fail to deserialize objects which it itself serialized).
+  # The cost of enabling this is that every persisted item incurs the cost of a deserialization.
+  validate-deserialization = off
+
   clock-skew-detection {
     # When the local clock and time in AWS response diverge by more than this duration
     # a warning is logged. Can be disabled by setting this to "off".

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -356,11 +356,14 @@ akka.persistence.dynamodb {
 
 akka.persistence.dynamodb {
   # If set to `on` (default is `off`), deserialize the item (event or snapshot) before persisting the serialized item.
-  # Enabling this prevents items which are not deserializable from being persisted, with the effect of
-  # reducing the chance of entities being unrecoverable or projections being blocked due to deserialization
-  # failures (these may still happen due to non-backward-compatible schema evolutions, but enabling this does
-  # validate that the present serialization does not fail to deserialize objects which it itself serialized).
-  # The cost of enabling this is that every persisted item incurs the cost of a deserialization.
+  # Enabling this prevents items which are not deserializable from being persisted.
+  #
+  # The cost of enabling this is that every persisted item incurs the cost of a deserialization: the performance
+  # impact of this may be visible in production.  Verification that everything which is serialized is deserializable
+  # by testing or static analysis is recommended.
+  #
+  # For unit tests, the EventSourcedBehaviorTestKit performs a stronger validation (that the deserialized item is equal
+  # to the serialized item).  Some may find it most useful to enable this for integration test environments.
   validate-deserialization = off
 
   clock-skew-detection {

--- a/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/DynamoDBSettings.scala
@@ -67,6 +67,8 @@ object DynamoDBSettings {
 
     val snapshotFallbackSettings = SnapshotFallbackSettings(config.getConfig("snapshot.fallback-store"))
 
+    val validateDeserialization = config.getBoolean("validate-deserialization")
+
     new DynamoDBSettings(
       journalTable,
       journalPublishEvents,
@@ -78,7 +80,8 @@ object DynamoDBSettings {
       snapshotBySliceGsi,
       clockSkewSettings,
       journalFallbackSettings,
-      snapshotFallbackSettings)
+      snapshotFallbackSettings,
+      validateDeserialization)
   }
 
   /**
@@ -103,13 +106,15 @@ final class DynamoDBSettings private (
     val snapshotBySliceGsi: String,
     val clockSkewSettings: ClockSkewSettings,
     val journalFallbackSettings: JournalFallbackSettings,
-    val snapshotFallbackSettings: SnapshotFallbackSettings) {
+    val snapshotFallbackSettings: SnapshotFallbackSettings,
+    val validateDeserialization: Boolean) {
   override def toString: String =
     s"DynamoDBSettings(journalTable=$journalTable, journalPublishEvents=$journalPublishEvents, " +
     s"snapshotTable=$snapshotTable, querySettings=$querySettings, cleanupSettings=$cleanupSettings, " +
     s"timeToLiveSettings=$timeToLiveSettings, journalBySliceGsi=$journalBySliceGsi, " +
     s"snapshotBySliceGsi=$snapshotBySliceGsi, clockSkewSettings=$clockSkewSettings, " +
-    s"journalFallbackSettings=$journalFallbackSettings, snapshotFallbackSettings=$snapshotFallbackSettings)"
+    s"journalFallbackSettings=$journalFallbackSettings, snapshotFallbackSettings=$snapshotFallbackSettings), " +
+    s"validateDeserialization=$validateDeserialization"
 }
 
 final class QuerySettings(config: Config) {

--- a/core/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -12,6 +12,7 @@ import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.util.control.NonFatal
 
 import akka.Done
 import akka.actor.ActorRef
@@ -23,6 +24,7 @@ import akka.persistence.AtomicWrite
 import akka.persistence.PersistentRepr
 import akka.persistence.SerializedEvent
 import akka.persistence.dynamodb.DynamoDBSettings
+import akka.persistence.dynamodb.InstrumentationProvider
 import akka.persistence.dynamodb.internal.InstantFactory
 import akka.persistence.dynamodb.internal.JournalDao
 import akka.persistence.dynamodb.internal.PubSub
@@ -41,7 +43,6 @@ import akka.serialization.Serializers
 import akka.stream.scaladsl.Sink
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException
-import akka.persistence.dynamodb.InstrumentationProvider
 
 /**
  * INTERNAL API
@@ -146,7 +147,7 @@ private[dynamodb] final class DynamoDBJournal(config: Config, cfgPath: String)
           // monotonically increasing, at least 1 microsecond more than previous timestamp
           val timestamp = InstantFactory.now()
 
-          SerializedJournalItem(
+          val ret = SerializedJournalItem(
             pr.persistenceId,
             pr.sequenceNr,
             timestamp,
@@ -157,6 +158,19 @@ private[dynamodb] final class DynamoDBJournal(config: Config, cfgPath: String)
             pr.writerUuid,
             tags,
             metadata)
+
+          if (settings.validateDeserialization) {
+            try {
+              deserializeItem(serialization, ret)
+            } catch {
+              case NonFatal(ex) =>
+                throw new IllegalArgumentException(
+                  s"Potential poison event of class [${event.getClass.getName}] was not deserializable",
+                  ex)
+            }
+          }
+
+          ret
         }
       }
 

--- a/core/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -165,7 +165,7 @@ private[dynamodb] final class DynamoDBJournal(config: Config, cfgPath: String)
             } catch {
               case NonFatal(ex) =>
                 throw new IllegalArgumentException(
-                  s"Potential poison event of class [${event.getClass.getName}] was not deserializable",
+                  s"Potential poison event of class [${event.getClass.getName}] was not deserializable: persistenceId [${pr.persistenceId}]",
                   ex)
             }
           }

--- a/core/src/main/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
@@ -119,7 +119,7 @@ private[dynamodb] final class DynamoDBSnapshotStore(cfg: Config, cfgPath: String
         } catch {
           case NonFatal(ex) =>
             throw new IllegalArgumentException(
-              s"Potential poison snapshot of class [${snapshot.getClass.getName}] was not deserializable",
+              s"Potential poison snapshot of class [${snapshot.getClass.getName}] was not deserializable: persistenceId=[${metadata.persistenceId}]",
               ex)
         }
       }

--- a/core/src/main/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.adapter._
@@ -112,6 +113,16 @@ private[dynamodb] final class DynamoDBSnapshotStore(cfg: Config, cfgPath: String
         tags,
         serializedMeta)
 
+      if (settings.validateDeserialization) {
+        try {
+          deserializeSnapshotItem(snapshotItem, serialization)
+        } catch {
+          case NonFatal(ex) =>
+            throw new IllegalArgumentException(
+              s"Potential poison snapshot of class [${snapshot.getClass.getName}] was not deserializable",
+              ex)
+        }
+      }
       snapshotDao.store(snapshotItem)
     }
   }

--- a/core/src/test/scala/akka/persistence/dynamodb/TestConfig.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/TestConfig.scala
@@ -11,17 +11,20 @@ object TestConfig {
   lazy val config: Config = {
     val defaultConfig = ConfigFactory.load()
 
+    val unluckyStringSerializerFQCN = classOf[akka.persistence.dynamodb.UnluckyStringSerializer].getName
+    val unluckyStringFQCN = classOf[akka.persistence.dynamodb.UnluckyString].getName
+
     ConfigFactory
-      .parseString("""
+      .parseString(s"""
       akka.loglevel = DEBUG
       akka.persistence.journal.plugin = "akka.persistence.dynamodb.journal"
       akka.persistence.snapshot-store.plugin = "akka.persistence.dynamodb.snapshot"
       akka.persistence.dynamodb.client.local.enabled = true
       akka.actor.testkit.typed.default-timeout = 10s
       akka.persistence.dynamodb.validate-deserialization = on
-      """ +
-      s"\nakka.actor.serializers.unlucky-string = \"${classOf[akka.persistence.dynamodb.UnluckyStringSerializer].getName}\"" +
-      s"\nakka.actor.serialization-bindings.\"${classOf[akka.persistence.dynamodb.UnluckyString].getName}\" = unlucky-string")
+      akka.actor.serialization-bindings."$unluckyStringFQCN" = unlucky-string
+      akka.actor.serializers.unlucky-string = "$unluckyStringSerializerFQCN"
+      """)
       .withFallback(defaultConfig)
   }
 

--- a/core/src/test/scala/akka/persistence/dynamodb/TestConfig.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/TestConfig.scala
@@ -18,7 +18,10 @@ object TestConfig {
       akka.persistence.snapshot-store.plugin = "akka.persistence.dynamodb.snapshot"
       akka.persistence.dynamodb.client.local.enabled = true
       akka.actor.testkit.typed.default-timeout = 10s
-      """)
+      akka.persistence.dynamodb.validate-deserialization = on
+      """ +
+      s"\nakka.actor.serializers.unlucky-string = \"${classOf[akka.persistence.dynamodb.UnluckyStringSerializer].getName}\"" +
+      s"\nakka.actor.serialization-bindings.\"${classOf[akka.persistence.dynamodb.UnluckyString].getName}\" = unlucky-string")
       .withFallback(defaultConfig)
   }
 

--- a/core/src/test/scala/akka/persistence/dynamodb/TestSerializer.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/TestSerializer.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024-2026 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.dynamodb
+
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.nowarn
+
+import akka.serialization.SerializerWithStringManifest
+
+case class UnluckyString(string: String)
+
+// A pathological serializer: it will serialize objects with any string length, but
+// will fail to deserialize strings of length 7
+class UnluckyStringSerializer extends SerializerWithStringManifest {
+  val Manifest = "UnluckyString"
+  val Utf8 = StandardCharsets.UTF_8.name
+
+  def identifier = 0xee1e777b
+
+  def manifest(obj: AnyRef) = Manifest
+
+  @nowarn("msg=may not be exhaustive")
+  def toBinary(obj: AnyRef) =
+    obj match {
+      case UnluckyString(string) => string.getBytes(Utf8)
+    }
+
+  def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+    manifest match {
+      case Manifest =>
+        if (bytes.length != 7) UnluckyString(new String(bytes, Utf8))
+        else throw new RuntimeException("Unlucky Number 7!")
+
+      case _ => throw new IllegalArgumentException(s"Unknown manifest $manifest")
+    }
+}

--- a/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration._
 import scala.jdk.FutureConverters.CompletionStageOps
 import scala.util.Random
 
+import akka.Done
 import akka.actor.ActorRef
 import akka.actor.ClassicActorSystemProvider
 import akka.actor.testkit.typed.scaladsl.LogCapturing
@@ -49,7 +50,6 @@ import akka.serialization.Serializers
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestProbe
-import akka.Done
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.Inspectors

--- a/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
@@ -17,6 +17,7 @@ import akka.actor.ClassicActorSystemProvider
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.{ TestProbe => TypedTestProbe }
+import akka.actor.typed.{ ActorRef => TypedActorRef }
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.adapter._
 import akka.persistence.AtomicWrite
@@ -39,12 +40,16 @@ import akka.persistence.dynamodb.internal.FallbackStoreProvider
 import akka.persistence.dynamodb.internal.InMemFallbackStore
 import akka.persistence.dynamodb.internal.InstantFactory
 import akka.persistence.dynamodb.util.ClientProvider
+import akka.persistence.dynamodb.UnluckyString
 import akka.persistence.journal.JournalSpec
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.persistence.typed.scaladsl.Effect
 import akka.serialization.SerializationExtension
 import akka.serialization.Serializers
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestProbe
+import akka.Done
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.Inspectors
@@ -520,6 +525,47 @@ class DynamoDBJournalWithEagerFallbackSpec
       eventually {
         FallbackStoreProvider(system).getFallbackStore(plugin) shouldNot be(empty)
       }
+    }
+  }
+}
+
+class DynamoDBPoisonEventSpec
+    extends ScalaTestWithActorTestKit(DynamoDBJournalSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  def typedSystem: ActorSystem[_] = testKit.system
+
+  class Setup {
+    val persistenceId = nextPersistenceId(nextEntityType())
+
+    def testBehavior(ref: TypedActorRef[Done]) = EventSourcedBehavior[String, UnluckyString, String](
+      persistenceId = persistenceId,
+      commandHandler = (_, str) => Effect.persist(UnluckyString(str)).thenRun(_ => ref ! Done),
+      eventHandler = (state, evt) => if (state.isEmpty) evt.string else s"$state|${evt.string}",
+      emptyState = "")
+
+    val journal = persistenceExt.journalFor("akka.persistence.dynamodb.journal")
+    val probe = testKit.createTestProbe[Any]()
+    val classicProbeRef = probe.ref.toClassic
+  }
+
+  "A DynamoDB journal" should {
+    "reject writes of events that cannot be deserialized" in new Setup {
+      val persistentActor = testKit.spawn(testBehavior(probe.ref.narrow))
+      persistentActor ! "hi"
+      probe.expectMessage(Done)
+      persistentActor ! "1234567"
+      probe.expectNoMessage()
+      probe.expectTerminated(persistentActor)
+
+      journal.tell(ReplayMessages(1, 10, 10, persistenceId.id, classicProbeRef), classicProbeRef)
+      val firstReplayed = probe.expectMessageType[ReplayedMessage]
+      firstReplayed.persistent.sequenceNr shouldBe 1
+      firstReplayed.persistent.payload shouldBe UnluckyString("hi")
+      probe.expectMessage(RecoverySuccess(1))
     }
   }
 }

--- a/core/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStoreSpec.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 import scala.jdk.FutureConverters.CompletionStageOps
 import scala.util.Random
 
+import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.testkit.typed.scaladsl.LogCapturing
@@ -19,6 +20,9 @@ import akka.actor.testkit.typed.scaladsl.{ TestProbe => TypedTestProbe }
 import akka.actor.typed.{ ActorRef => TypedActorRef }
 import akka.persistence.CapabilityFlag
 import akka.persistence.DeleteSnapshotSuccess
+import akka.persistence.JournalProtocol.ReplayedMessage
+import akka.persistence.JournalProtocol.ReplayMessages
+import akka.persistence.JournalProtocol.RecoverySuccess
 import akka.persistence.SaveSnapshotSuccess
 import akka.persistence.SnapshotMetadata
 import akka.persistence.SnapshotProtocol.DeleteSnapshot
@@ -29,11 +33,14 @@ import akka.persistence.SnapshotSelectionCriteria
 import akka.persistence.dynamodb.TestConfig
 import akka.persistence.dynamodb.TestData
 import akka.persistence.dynamodb.TestDbLifecycle
+import akka.persistence.dynamodb.UnluckyString
 import akka.persistence.dynamodb.internal.FallbackStoreProvider
 import akka.persistence.dynamodb.internal.InMemFallbackStore
 import akka.persistence.dynamodb.internal.SnapshotAttributes
 import akka.persistence.dynamodb.util.ClientProvider
 import akka.persistence.snapshot.SnapshotStoreSpec
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.persistence.typed.scaladsl.Effect
 import akka.serialization.SerializationExtension
 import akka.serialization.Serializers
 import akka.stream.testkit.scaladsl.TestSink
@@ -48,13 +55,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
-import akka.persistence.typed.scaladsl.EventSourcedBehavior
-import akka.persistence.typed.scaladsl.Effect
-import akka.Done
-import akka.persistence.dynamodb.UnluckyString
-import akka.persistence.JournalProtocol.ReplayedMessage
-import akka.persistence.JournalProtocol.ReplayMessages
-import akka.persistence.JournalProtocol.RecoverySuccess
 
 object DynamoDBSnapshotStoreSpec {
   val config: Config = TestConfig.config

--- a/core/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStoreSpec.scala
@@ -16,6 +16,7 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.{ TestProbe => TypedTestProbe }
+import akka.actor.typed.{ ActorRef => TypedActorRef }
 import akka.persistence.CapabilityFlag
 import akka.persistence.DeleteSnapshotSuccess
 import akka.persistence.SaveSnapshotSuccess
@@ -47,6 +48,13 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.persistence.typed.scaladsl.Effect
+import akka.Done
+import akka.persistence.dynamodb.UnluckyString
+import akka.persistence.JournalProtocol.ReplayedMessage
+import akka.persistence.JournalProtocol.ReplayMessages
+import akka.persistence.JournalProtocol.RecoverySuccess
 
 object DynamoDBSnapshotStoreSpec {
   val config: Config = TestConfig.config
@@ -366,5 +374,86 @@ class DynamoDBSnapshotFallbackSpec
     invocationsProbe.request(1)
     test(fallbackStore, invocationsProbe)
     invocationsProbe.cancel()
+  }
+}
+
+class DynamoDBPoisonSnapshotSpec
+    extends ScalaTestWithActorTestKit(DynamoDBSnapshotStoreSpec.config)
+    with AnyWordSpecLike
+    with TestData
+    with TestDbLifecycle
+    with LogCapturing {
+  def typedSystem: ActorSystem[_] = testKit.system
+
+  class Setup {
+    val persistenceId = nextPersistenceId(nextEntityType())
+
+    def testBehavior(ref: TypedActorRef[Done]) = EventSourcedBehavior[String, String, UnluckyString](
+      persistenceId = persistenceId,
+      emptyState = UnluckyString(""),
+      commandHandler = (state, str) =>
+        if (state.string.endsWith("|sealed")) {
+          ref ! Done
+          if (str == "stop") Effect.stop() else Effect.none
+        } else Effect.persist(str).thenRun(_ => ref ! Done),
+      eventHandler =
+        (state, evt) => if (state.string.isEmpty) UnluckyString(evt) else UnluckyString(s"${state.string}|$evt"))
+      .snapshotWhen((_, _, seqNr) => (seqNr % 2) == 0)
+
+    val journal = persistenceExt.journalFor("akka.persistence.dynamodb.journal")
+    val snapshotStore = persistenceExt.snapshotStoreFor("akka.persistence.dynamodb.snapshot")
+    val probe = testKit.createTestProbe[Any]()
+    val classicProbeRef = probe.ref.toClassic
+  }
+
+  "A DynamoDB snapshot store" should {
+    "not persist snapshots that can't be deserialized" in new Setup {
+      val persistentActor = testKit.spawn(testBehavior(probe.ref.narrow))
+      persistentActor ! "hi"
+      probe.expectMessage(Done)
+      // state is "hi"
+      persistentActor ! "heyo"
+      // state is "hi|heyo"... snapshot is requested but is not written
+      probe.expectMessage(Done)
+
+      snapshotStore.tell(
+        LoadSnapshot(persistenceId.id, SnapshotSelectionCriteria.Latest, Long.MaxValue),
+        classicProbeRef)
+
+      probe.expectMessageType[LoadSnapshotResult].snapshot shouldBe empty
+
+      persistentActor ! "stop"
+      probe.expectMessage(Done)
+      persistentActor ! "sealed"
+      probe.expectMessage(Done)
+
+      snapshotStore.tell(
+        LoadSnapshot(persistenceId.id, SnapshotSelectionCriteria.Latest, Long.MaxValue),
+        classicProbeRef)
+
+      var snapshot = probe.expectMessageType[LoadSnapshotResult]
+      snapshot.snapshot shouldNot be(empty)
+      snapshot.snapshot.get.snapshot shouldBe UnluckyString("hi|heyo|stop|sealed")
+
+      journal.tell(ReplayMessages(1, 10, 10, persistenceId.id, classicProbeRef), classicProbeRef)
+      probe.receiveMessages(4).iterator.map(_.getClass).toSet should contain theSameElementsAs (Set(
+        classOf[ReplayedMessage]))
+      probe.expectMessage(RecoverySuccess(4))
+
+      persistentActor ! "stop"
+      probe.expectMessage(Done)
+      probe.expectTerminated(persistentActor)
+
+      snapshotStore.tell(
+        LoadSnapshot(persistenceId.id, SnapshotSelectionCriteria.Latest, Long.MaxValue),
+        classicProbeRef)
+
+      snapshot = probe.expectMessageType[LoadSnapshotResult]
+      snapshot.snapshot shouldNot be(empty)
+      snapshot.snapshot.get.snapshot shouldBe UnluckyString("hi|heyo|stop|sealed")
+
+      journal.tell(ReplayMessages(snapshot.toSequenceNr + 1, 10, 5, persistenceId.id, classicProbeRef), classicProbeRef)
+      probe.expectMessage(RecoverySuccess(4))
+    }
   }
 }


### PR DESCRIPTION
If an event or snapshot is persisted which cannot be deserialized (can be said to be "poison"):

* the persisting entity becomes unrecoverable
* any projection consuming the events/snapshots will be blocked from proceeding

Not being able to deserialize the event/snapshot indicates a bug in the application code (note that some of the standard Jackson serializers have this bug (e.g. dates in the year zero are writable by the serializer but not deserializable): the bug can be in a dependency pulled in), but it's arguably better to detect this before writing the item which can't be deserializable and fail fast.