### PR TITLE
Replace hardcoded repo.akka.io/maven references

### DIFF
--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -23,15 +23,15 @@ Key links:
 - [ ] Update the revision in Fossa in the Akka Group for the Akka umbrella version, e.g. `22.10`. Note that the revisions for the release is udpated by Akka Group > Projects > Edit. For recent dependency updates the Fossa validation can be triggered from the GitHub actions "Dependency License Scanning".
 - [ ] Wait until [main build finished](https://github.com/akka/akka-persistence-dynamodb/actions) after merging the latest PR
 - [ ] Update the [draft release](https://github.com/akka/akka-persistence-dynamodb/releases) with the next tag version `v$VERSION$`, title and release description. Use the `Publish release` button, which will create the tag.
-- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-persistence-dynamodb/actions) for the new tag and publish artifacts to https://repo.akka.io/maven)
+- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-persistence-dynamodb/actions) for the new tag and publish artifacts to the Akka repository)
 
 ### Check availability
 
 - [ ] Check [API](https://doc.akka.io/api/akka-persistence-dynamodb/$VERSION$/) documentation
 - [ ] Check [reference](https://doc.akka.io/libraries/akka-persistence-dynamodb/$VERSION$/) documentation. Check that the reference docs were deployed and show a version warning (see section below on how to fix the version warning).
-- [ ] Check the release on https://repo.akka.io/maven/com/lightbend/akka/akka-persistence-dynamodb_2.13/$VERSION$/akka-persistence-dynamodb_2.13-$VERSION$.pom
+- [ ] Check the release using your token resolver URL from https://account.akka.io/token: `mvn dependency:get -Dartifact=com.lightbend.akka:akka-persistence-dynamodb_2.13:$VERSION$ -Dmaven.repo.remote=<token url>`
 
-### When everything is on https://repo.akka.io/maven
+### When everything is available in the Akka repository
   - [ ] Log into `gustav.akka.io` as `akkarepo`
     - [ ] If this updates the `current` version, run `./update-akka-persistence-dynamodb-current-version.sh $VERSION$ 2.0`
     - [ ] otherwise check changes and commit the new version to the local git repository

--- a/docs/src/main/paradox/fallback.md
+++ b/docs/src/main/paradox/fallback.md
@@ -21,7 +21,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 Additionally, add the dependency as below.

--- a/docs/src/main/paradox/getting-started.md
+++ b/docs/src/main/paradox/getting-started.md
@@ -8,7 +8,7 @@ for this repository.
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 Additionally, add the dependency as below.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -13,7 +13,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 Additionally, add the dependency as below.

--- a/samples/guide/shopping-cart-java/shopping-analytics-service/pom.xml
+++ b/samples/guide/shopping-cart-java/shopping-analytics-service/pom.xml
@@ -38,7 +38,7 @@
         <repository>
             <id>akka-repository</id>
             <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven</url>
+            <url>REPLACE_WITH_REPO_URL_FROM_https://account.akka.io/token</url>
         </repository>
         <repository>
             <id>akka-snapshot-repository</id>
@@ -50,7 +50,7 @@
         <pluginRepository>
             <id>akka-repository</id>
             <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven</url>
+            <url>REPLACE_WITH_REPO_URL_FROM_https://account.akka.io/token</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/samples/guide/shopping-cart-java/shopping-cart-service/pom.xml
+++ b/samples/guide/shopping-cart-java/shopping-cart-service/pom.xml
@@ -38,7 +38,7 @@
         <repository>
             <id>akka-repository</id>
             <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven</url>
+            <url>REPLACE_WITH_REPO_URL_FROM_https://account.akka.io/token</url>
         </repository>
         <repository>
             <id>akka-snapshot-repository</id>
@@ -50,7 +50,7 @@
         <pluginRepository>
             <id>akka-repository</id>
             <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven</url>
+            <url>REPLACE_WITH_REPO_URL_FROM_https://account.akka.io/token</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Remove hardcoded `https://repo.akka.io/maven` URLs:

- `docs/src/main/paradox/overview.md`, `fallback.md`, `getting-started.md`: use `<url from https://account.akka.io/token>` in `@@repository` blocks
- `docs/release-train-issue-template.md`: update publish step and check-availability step; use token URL pattern for the `mvn dependency:get` check command
- `samples/guide/shopping-cart-java/*/pom.xml`: replace with `REPLACE_WITH_REPO_URL_FROM_https://account.akka.io/token` placeholder